### PR TITLE
ace-am: Increased table size and font size, improved UI display.

### DIFF
--- a/ace-am/src/main/webapp/eventlog.jsp
+++ b/ace-am/src/main/webapp/eventlog.jsp
@@ -34,7 +34,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         <style type="text/css">
             #logtypeselection
             {
-                width: 75%;
+                width: 90%;
                 margin-left: auto;
                 margin-top: 0px;
                 margin-right: auto;
@@ -88,12 +88,13 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
             .log {
                 margin-left: auto;
                 margin-right: auto;
-                width: 720px;
+                width: 90%;
                 border-left: 1px solid #000000;
                 border-right: 1px solid #000000;
                 border-bottom: 1px solid #000000;
                 margin-bottom: 10px;
                 margin-top:10px;
+                min-height: 90px;
             }
             
         </style>
@@ -102,8 +103,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         <jsp:include page="header.jsp" />
         <script type="text/javascript">document.getElementById('log').style.backgroundColor = '#ccccff';</script>
         
-        
-        <table id="logtypeselection">
+        <div align="center">
+          <table id="logtypeselection">
             
             <c:if test="${sessionId > 0}">
                 <tr><td colspan="7">
@@ -146,9 +147,9 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                 <td align="center"><input onClick="javascript:toggleSelected('sync'); return false;" ${selects['sync']} type="checkbox" style="border:none"/></td> 
             </tr>
             
-        </table>
+          </table>
         
-        <c:if test="${loglist != null}">
+          <c:if test="${loglist != null}">
             <div class="log">
                 <c:forEach var="item" items="${loglist}">
                     <div id="logEntries" class="logItem"
@@ -178,7 +179,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                     </div>
                 </c:forEach>
             </div>
-        </c:if>
+          </c:if>
+        </div>
         
         <table id="browselinktable" >
             <tr>

--- a/ace-am/src/main/webapp/report.jsp
+++ b/ace-am/src/main/webapp/report.jsp
@@ -23,7 +23,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
     <style type="text/css">
         body {
-            width: 752px !important;
+            width: 980px !important;
             margin-top: 8px !important;
             padding-right: 0px !important;
         }
@@ -37,16 +37,18 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         }
 
         #summaryTable {
-            margin-left: 50px;
             margin-right: auto;
         }
 
         .lblTd {
-            padding-left: 50px;
+            min-width: 200px;
+            white-space: nowrap;
         }
 
         .dataTd {
             padding-left: 10px;
+            padding-right: 10px;
+            min-width: 50px;
         }
 
         #reportTable {
@@ -70,7 +72,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         }
 
         .tblLinks {
-            padding-left: 50px;
+            margin-right: 24px;
         }
 
     </style>
@@ -79,7 +81,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 <jsp:include page="header.jsp"/>
 <jsp:useBean id="collection" scope="request"
              type="edu.umiacs.ace.monitor.access.CollectionSummaryBean"/>
-<table id="summaryTable">
+<div class="container" style="width: 90%; margin-bottom: 20px;">
+  <table id="summaryTable">
     <tr>
         <td class="lblTd">Active Files</td>
         <td class="dataTd">
@@ -127,24 +130,26 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         </td>
     </tr>
     <tr>
-        <td class="tblLinks">
+      <td colspan="6">
+        <span class="tblLinks">
             <a href="Report?collectionid=${collection.collection.id}&amp;text=1&amp;count=-1">
-                Download List</a></td>
+                Download List</a></span>
         <um:Auth role="Audit">
-        <td class="tblLinks">
+        <span class="tblLinks">
             <a href="StartSync?collectionid=${collection.collection.id}&amp;type=corrupt">
                 Audit Corrupt Files
             </a>
-        </td>
+        </span>
         </um:Auth>
         <um:Auth role="Log">
-        <td class="tblLinks">
+        <span class="tblLinks">
             <a href="EventLog?sessionId=${session}">Recent Events</a>
-        </td>
+        </span>
         </um:Auth>
+      </td>
     </tr>
-</table>
-
+  </table>
+</div>
 
 <form method="GET" action="RemoveItem">
     <div class="container" style="width: 90%">

--- a/ace-am/src/main/webapp/settings.jsp
+++ b/ace-am/src/main/webapp/settings.jsp
@@ -16,10 +16,18 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <title>System Settings</title>
     <link rel="stylesheet" type="text/css" href="style.css"/>
+    <style type="text/css">
+        body {
+            width: 980px !important;
+            margin-top: 8px !important;
+            padding: 0px !important;
+        }
+    </style>  
 </head>
 <body>
 <jsp:include page="header.jsp"/>
 <FORM name="settingsform" METHOD="POST" ENCTYPE="multipart/form-data" ACTION="UpdateSettings">
+  <div align="center">
     <fieldset id="settingsTable">
         <legend class="form-legend">System Settings</legend>
         <div class="tabs">
@@ -271,6 +279,7 @@
         <input type="submit" value="Set Defaults" name="default" class="btn is-secondary"
                style="width: 125px;">
     </div>
+  </div>
 </FORM>
 
 <jsp:include page="footer.jsp"/>

--- a/ace-am/src/main/webapp/statistics.jsp
+++ b/ace-am/src/main/webapp/statistics.jsp
@@ -1,4 +1,6 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
@@ -11,7 +13,7 @@
          * a few fixes to make everything in line with the rest of ACE
          */
         body {
-            width: 752px !important;
+            width: 980px !important;
             margin-top: 8px !important;
         }
 
@@ -38,13 +40,15 @@
             margin: 1rem -15px;
             background-color: #f7f7f9;
             -ms-overflow-style: -ms-autohiding-scrollbar;
+            width: 90%;
+            min-height: 120px;
         }
     </style>
 </head>
 <body>
 <jsp:include page="header.jsp"/>
 <h3 style="text-align: center;">Collection Ingestion Report</h3>
-<div class="container">
+<div align="center">
     <div id="searchtable">
         <form method="POST" role="form">
             <div class="form-group">
@@ -76,14 +80,17 @@
                 </div>
             </div>
 
-            <button type="submit" class="btn btn-primary"
-                    value="Submit"><span>Submit</span></button>
-            <button type="submit" class="btn btn-primary" name="csv"
-                    value="true" style="width: 10rem;"><span>Download As CSV</span></button>
+            <div align="left">
+                <button type="submit" class="btn btn-primary"
+                        value="Submit"><span>Submit</span></button>
+                <button type="submit" class="btn btn-primary" name="csv"
+                        value="true" style="width: 10rem;"><span>Download As CSV</span></button>
+            </div>
         </form>
     </div>
 
-    <div class="results">
+    <div align="center">
+      <div class="results">
         <table class="table table-sm">
             <thead>
             <tr>
@@ -106,6 +113,7 @@
             </c:forEach>
             </tbody>
         </table>
+      </div>
     </div>
 </div>
 <jsp:include page="footer.jsp"/>

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -147,7 +147,7 @@
 
         </c:if>
 
-        <div id="searchtable">
+        <div id="searchtable" align="center">
             <form method="GET" role="form">
                 <div class="input">
                     <span class="input-group-addon">Group</span>
@@ -176,10 +176,14 @@
                     </select>
                 </div>
 
-                <button type="submit" class="btn is-secondary" value="Submit"><span>Submit</span></button>
+                <div class="input" align="left">
+                    <button type="submit" class="btn is-secondary" value="Submit"><span>Submit</span></button>
+                </div>
             </form>
         </div>
-        <table id="statustable">
+
+        <div style="width: 100%" align="center">
+          <table id="statustable">
             <thead>
                 <td></td><td width="45%">Collection Name</td>
                 <td>Type</td><td>Total Files*</td>
@@ -290,7 +294,8 @@
                         <c:otherwise>Automated auditing active.</c:otherwise>
                     </c:choose></td></tr>
 
-        </table>
+          </table>
+        </div>
 
        <table id="linktable">
             <tr>

--- a/ace-am/src/main/webapp/style.css
+++ b/ace-am/src/main/webapp/style.css
@@ -1,8 +1,8 @@
 body {
     font-family: Arial, Helvetica, sans-serif;
-    font-size: 10px;
-    width: 750px;
-    border: 1px solid #000000;
+    font-size: 16px;
+    width: 980px;
+    border: 2px solid #000000;
     margin-left: auto !important;
     margin-right: auto !important;
 }
@@ -14,7 +14,7 @@ h1 {
 }
 
 a:link, a:visited {
-    font-size: 12px;
+    font-size: 16px;
     color: #003388;
     text-decoration: none;
 }
@@ -28,7 +28,7 @@ a img {
 }
 
 input {
-    font-size: 12px;
+    font-size: 16px;
 }
 
 /*
@@ -64,7 +64,7 @@ ul {
 }
 
 .standardBody {
-    font-size: 12px;
+    font-size: 16px;
     margin-top: 0px;
     margin-bottom: 25px;
     margin-left: 50px;
@@ -86,7 +86,7 @@ padding: 0px;
 padding-left: 15px;
 padding-right: 15px;
 border-bottom: 1px solid #000000;
-font-size: x-small;
+font-size: 16px;
 }
 
 .menubar table {
@@ -160,7 +160,7 @@ vertical-align: top;
     height: 100px;
     position: absolute;
     color: black;
-    font-size: small;
+    font-size: 16px;
 }
 
 #statustable thead {
@@ -173,16 +173,15 @@ vertical-align: top;
 
 #statustable tr td {
     padding-left: 5px;
+    height: 24px;
 }
 
 #statustable {
-    font-size: small;
+    font-size: 16px;
     border: 1px solid #000000;
     margin-top: 25px;
     margin-bottom: 25px;
-    margin-left: 50px;
-    margin-right: 50px;
-    width: 650px;
+    width: 96%;
 }
 
 #dettable tr td {
@@ -191,11 +190,11 @@ vertical-align: top;
 }
 
 #details {
-    font-size: small;
+    font-size: 16px;
     margin-top: 0px;
     margin-left: 50px;
     margin-right: 50px;
-    width: 650px;
+    width: 90%;
 }
 
 .logtypeselection {
@@ -204,16 +203,16 @@ vertical-align: top;
 }
 
 #settingsTable {
-    font-size: small;
+    width: 70%;
+    font-size: 16px;
     border: 1px solid #000000;
-    margin-left: 5%;
-    margin-right: 5%;
+    padding: 20px 60px;
 }
 
 .settingsRow {
     margin-top: 5px;
     margin-bottom: 5px;
-    height: 20px;
+    height: 24px;
     width: 100%;
     clear: both;
 }
@@ -260,37 +259,37 @@ vertical-align: top;
     margin-bottom: -10px;
     margin-left: auto;
     margin-right: auto;
-    width: 650px;
+    width: 90%;
 }
 
 .input {
     padding: 2px;
     display: flex;
-    width: 650px;
+    width: 720px;
 }
 
 .input-group-addon {
     border: 1px solid #ccc;
-    font-size: 12px;
+    font-size: 16px;
     background-color: #e8e8e8;
     text-align: center;
-    width: 75px;
-    height: 20px;
-    line-height: 20px;
-    padding: 3px 10px;
+    width: 20%;
+    padding: 6px;
+    font-weight: bold;
+    color: #333;
 }
 
 .form-input {
     border: 1px solid #ccc;
-    width: 100%;
-    padding: 3px 8px;
+    width: 80%;
+    padding: 6px 8px;
     margin-left: -1px;
     margin-right: 5px;
 }
 
 .form-select {
     border: 1px solid #ccc;
-    width: 100%;
+    width: 80%;
     margin-left: -3px;
     margin-right: 5px;
 }
@@ -338,7 +337,7 @@ vertical-align: top;
 
 .form-help {
     display: block;
-    font-size: 0.7rem;
+    font-size: 16px;
     margin-bottom: .25rem;
     margin-top: 0.25rem;
     text-align: center;
@@ -350,16 +349,15 @@ vertical-align: top;
 }
 
 .btn {
-    padding: 2px;
+    padding: 6px;
     width: 75px;
-    height: 25px;
     border: 1px solid #939393;
     border-radius: 0;
-    margin-left: 2px;
-    margin-top: 2px;
+    margin: 6px 2px 12px 2px;
     color: #363636;
     background-color: hsl(217, 100%, 82%);
-    font-size: 0.75rem;
+    font-size: 14px;
+    font-weight: bold;
 }
 
 .btn.is-secondary {

--- a/ace-am/src/main/webapp/usermodify.jsp
+++ b/ace-am/src/main/webapp/usermodify.jsp
@@ -24,7 +24,7 @@ Author     : toaster
             }
 
             #usertablehead {
-                padding: 10px;
+                padding: 10px 0px;
 
             }
         </style>


### PR DESCRIPTION
Related to #1 

Increase table size and default font size for ace-am, improved UI display.

**Screenshots:**
Before changes:
<img width="1440" alt="Screen Shot -status page - before changes" src="https://user-images.githubusercontent.com/2430784/156239888-2b81004c-d166-48e9-9d06-5b898f058a2f.png">


After changes:

- Status table (index page):
<img width="1440" alt="Screen Shot - ace-status-page" src="https://user-images.githubusercontent.com/2430784/156226154-d7615022-553f-4542-9a39-82645d16b912.png">

- Even log:
<img width="1439" alt="Screen Shot - ace-event-log-page" src="https://user-images.githubusercontent.com/2430784/156226401-cee90565-fd3b-492b-b033-f45e2ad74cfd.png">

- Accounts page:
<img width="1440" alt="Screen Shot - ace-accounts-page" src="https://user-images.githubusercontent.com/2430784/156226564-e2828ced-8533-4226-ab54-f6f4963457bf.png">

- System Settings:
<img width="1440" alt="Screen Shot - ace-system-settings-page" src="https://user-images.githubusercontent.com/2430784/156226689-2c4563ca-5659-4ce1-944a-640d8068cfbc.png">

- Reports page:
<img width="1439" alt="Screen Shot - ace-report-page" src="https://user-images.githubusercontent.com/2430784/156226764-f7bc6594-ef5b-4de3-a20c-658e4b40f441.png">
