### PR TITLE
Add group label for Group names.

### DIFF
--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -133,7 +133,11 @@
                 background-color: #e8e8e8;
             }
 
-
+            .lbl-group
+            {
+            	color: #444444;
+            	width: 100%;
+            }
         </style>
     </head>
 
@@ -201,9 +205,14 @@
 
                     <tr>
                         <td class="groupheader" colspan="3" onclick="toggleVisibility('spexpand${group}','inline'); toggleVisibility('sphide${group}','inline');">
-                            <span onclick="showGroup('grouptr${group}')" id="spexpand${group}" style="display:none;float: left;width: 25px;" >[+]</span>
-                            <span onclick="hideGroup('grouptr${group}')" id="sphide${group}" style="display:inline;float: left;width: 25px;" >[-]</span>
-                            ${group}
+                        	<div onclick="showGroup('grouptr${group}')" id="spexpand${group}" style="display:none;cursor: pointer;" >
+                        		<div class="lbl-group">[+] Group:</div>
+                        		<div style="margin-left:20px;">${group}</div>
+                        	</div>
+                        	<div onclick="hideGroup('grouptr${group}')" id="sphide${group}" style="display:inline;cursor: pointer;" >
+                        		<div class="lbl-group">[-] Group:</div>
+                        		<div style="margin-left:20px;">${group}</div>
+                        	</div>
                         </td>
                         <td class="groupheader" colspan="3" id="group${group}">
                                 ${group_count} /<c:choose><c:when test="${size > 0}"><d:FileSize value="${size}" /></c:when><c:otherwise>0 B</c:otherwise></c:choose>


### PR DESCRIPTION
Related ticket: #2 

Add group label for Group names.

Screenshots:
<img width="1439" alt="Screen Shot - ACE Group label open" src="https://user-images.githubusercontent.com/2430784/158254086-49a525e3-5228-42ed-8aad-3fc64fda00db.png">
<img width="1438" alt="Screen Shot - ACE group label closed" src="https://user-images.githubusercontent.com/2430784/158254174-9c3506a4-7af7-470f-badd-aa641c197934.png">
