### PR TITLE
Show all Groups collapsed on the first page rather than expanded.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
@@ -65,6 +65,7 @@ public class StatusServlet extends EntityManagerServlet {
     private static final String PAGE_STATES = "states";
     private static final String PAGE_COUNT = "count";
     private static final String PAGE_NUMBER = "page";
+    private static final String ACTION_SEARCH = "search";
 
     private static final long DEFAULT_PAGE = 0;
     private static final int DEFAULT_COUNT = 100;
@@ -85,6 +86,7 @@ public class StatusServlet extends EntityManagerServlet {
     private static final String PARAM_STATE_INTERRUPTED = "status_state_interrupted";
     private static final String PARAM_COLLECTION_LIKE = "status_collection";
     private static final String PARAM_AUDIT_DATE = "audit";
+    private static final String PARAM_ACTION = "action";
 
     // Filter params?
     // ...group
@@ -107,6 +109,7 @@ public class StatusServlet extends EntityManagerServlet {
         List<Collection> items;
         List<Collection> errorItems;
         List<Collection> noGroupItems;
+        List<String> collectionGroups;
 
         long page = getParameter(request, PARAM_PAGE, DEFAULT_PAGE);
         int count = (int) getParameter(request, PARAM_COUNT, DEFAULT_COUNT);
@@ -115,6 +118,7 @@ public class StatusServlet extends EntityManagerServlet {
         String group = getParameter(request, PARAM_GROUP, null);
         String state = getParameter(request, PARAM_STATE, null);
         String collection = getParameter(request, PARAM_COLLECTION_LIKE, null);
+        String action = getParameter(request, PARAM_ACTION, null);
         // String date = getParameter(request, PARAM_GROUP, null);
         PageBean pb = new PageBean((int) page, count, "");
 
@@ -222,12 +226,22 @@ public class StatusServlet extends EntityManagerServlet {
             errorCollections.add(csb);
         }
 
-        noGroupItems = getNoGroupCollections(items);
+        collectionGroups = new ArrayList<>();
         noGroupCollections = new ArrayList<>();
+        if (action != null && action.trim().equalsIgnoreCase(ACTION_SEARCH)) {
+        	// Search action
+        	collectionGroups = getCollectionGroups(items);
+            noGroupItems = getNoGroupCollections(items);      	
+        } else {
+        	// Browser groups action
+        	collectionGroups = searchCollectionGroups(em);
+        	noGroupItems = searchNoGroupCollections(em); 
+        }
+
         for (Collection col : noGroupItems) {
             CollectionSummaryBean csb = createCollectionSummary(col);
             noGroupCollections.add(csb);
-        }
+        }  
 
         request.setAttribute(PAGE_COLLECTIONS, collections);
         request.setAttribute(ERROR_COLLECTIONS, errorCollections);
@@ -235,7 +249,8 @@ public class StatusServlet extends EntityManagerServlet {
         request.setAttribute(PAGE_STATES, ImmutableList.copyOf(CStateBean.values()));
         request.setAttribute(PAGE_COUNT, count);
         request.setAttribute(PAGE_NUMBER, pb);
-        request.setAttribute("colGroups", getCollectionGroups(em));
+        request.setAttribute("action", action);
+        request.setAttribute("colGroups", collectionGroups);
         request.setAttribute("groups", GroupSummaryContext.summaries);
         if (hasJson(request)) {
             dispatcher = request.getRequestDispatcher("status-json.jsp");
@@ -266,7 +281,7 @@ public class StatusServlet extends EntityManagerServlet {
     	return query.getResultList();
     }
 
-    private List<String> getCollectionGroups(EntityManager em) {
+    private List<String> searchCollectionGroups(EntityManager em) {
     	StringBuilder queryBuilder = new StringBuilder();
     	queryBuilder.append("SELECT DISTINCT c.group FROM Collection c");
     	queryBuilder.append(" WHERE c.group IS NOT NULL AND  c.group <> '' ");
@@ -278,10 +293,31 @@ public class StatusServlet extends EntityManagerServlet {
     	return query.getResultList();
     }
 
+    private List<String> getCollectionGroups(List<Collection> collections) {
+    	return collections.stream().filter(x -> x.getGroup() != null && x.getGroup().length() > 0).map(x -> {return x.getGroup();}).distinct().collect(Collectors.toList());
+    }
+
     private List<Collection> getNoGroupCollections(List<Collection> collections) {
     	return collections.stream().filter(c -> c.getGroup() == null || c.getGroup().length() == 0).collect(Collectors.toList());
     }
 
+    /**
+     * 
+     * @param em
+     * @return
+     */
+    private List<Collection> searchNoGroupCollections(EntityManager em) {
+    	StringBuilder queryBuilder = new StringBuilder();
+    	queryBuilder.append("SELECT c FROM Collection c");
+    	queryBuilder.append(" WHERE c.group IS NULL OR c.group = '' ");
+    	queryBuilder.append(" ORDER BY c.name ASC");
+
+        TypedQuery<Collection> query =
+                em.createQuery(queryBuilder.toString(), Collection.class);
+
+    	return query.getResultList();
+    }
+ 
     private void setWorkingCollection(HttpServletRequest request, EntityManager em) {
         long collectionId;
         String idParam = request.getParameter(PARAM_COLLECTION_ID);

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -47,7 +47,7 @@
 
                 for (i = 0; i < divs.length; i++)
                 {
-                    if (divs[i].className.indexOf(id) != -1)
+                    if (divs[i].className.split(' ').includes(id))
                     {
                         divs[i].style.display = "";
                     }
@@ -55,6 +55,12 @@
             }
             function browseGroup(group)
             {
+                var action = document.getElementById('action').value;
+            	if (action == 'search')
+            	{
+            	    showGroup(grouptr + group)
+            	    return;
+            	}
                 document.getElementById('group-filter').value = group;
 
                 document.getElementById("searchForm").submit();
@@ -66,7 +72,7 @@
 
                 for (i = 0; i < divs.length; i++)
                 {
-                    if (divs[i].className.indexOf(id) != -1)
+                    if (divs[i].className.split(' ').includes(id))
                     {
                         divs[i].style.display = "none";
                     }
@@ -74,10 +80,13 @@
             }
             function collapseGroups()
             {
-                var group = document.getElementById('group-filter').value.trim()
+                var action = document.getElementById('action').value;
+                if (action === 'search')
+                    return;
+                
+                var group = document.getElementById('group-filter').value.trim();
                 var divs = document.getElementsByTagName('tr');
 
-                var currGroup = '';
                 for (i = 0; i < divs.length; i++)
                 {
                 	var iclass = divs[i].className;
@@ -92,7 +101,7 @@
                             document.getElementById('sphide' + igroup).style.display = 'inline';
                         }
                     }
-                    else if (iclass.indexOf(statusrow) == 0 && iclass != statusrow && (group.length == 0 || iclass.indexOf(group) < 0))
+                    else if (iclass.indexOf(statusrow) == 0 && iclass != statusrow && (group.length == 0 || !iclass.endsWith(grouptr + group)))
                     {
                         divs[i].style.display = "none";
                     }

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -26,14 +26,14 @@
         <title>ACE Audit Manager</title>
         <script type="text/javascript" SRC="srbFunctions.js" ></script>
         <script type="text/javascript">
-            function toggleVisibility(id,type) {
+            var groupheaderrow = 'groupheaderrow';
+            var grouptr = 'grouptr';
+            var statusrow = 'statusrow';
 
+            function toggleVisibility(id,type) {
                 var t = document.getElementById(id);
-                if (t.style.display == type) {
-                    t.style.display = "none";
-                } else {
-                    t.style.display = type;
-                }
+                var display = t.style.display;
+                t.style.display = display === 'none' ? 'inline' : 'none';
             }
             function showGroup(id)
             {
@@ -47,6 +47,13 @@
                     }
                 }
             }
+            function searchGroup(group)
+            {
+                document.getElementById('group-filter').value = group;
+
+                document.getElementById("searchForm").submit();
+                
+            }
             function hideGroup(id)
             {
                 var divs = document.getElementsByTagName('tr');
@@ -54,6 +61,32 @@
                 for (i = 0; i < divs.length; i++)
                 {
                     if (divs[i].className.indexOf(id) != -1)
+                    {
+                        divs[i].style.display = "none";
+                    }
+                }
+            }
+            function collapseGroups()
+            {
+                var group = document.getElementById('group-filter').value.trim()
+                var divs = document.getElementsByTagName('tr');
+
+                var currGroup = '';
+                for (i = 0; i < divs.length; i++)
+                {
+                	var iclass = divs[i].className;
+
+                    if (iclass.indexOf(groupheaderrow) == 0) {
+                        var igroup = iclass.substring(iclass.indexOf(groupheaderrow) + groupheaderrow.length);
+                        if (group != igroup) {
+                            document.getElementById('spexpand' + igroup).style.display = 'inline';
+                            document.getElementById('sphide' + igroup).style.display = 'none';
+                        } else {
+                            document.getElementById('spexpand' + igroup).style.display = 'none';
+                            document.getElementById('sphide' + igroup).style.display = 'inline';
+                        }
+                    }
+                    else if (iclass.indexOf(statusrow) == 0 && iclass != statusrow && (group.length == 0 || iclass.indexOf(group) < 0))
                     {
                         divs[i].style.display = "none";
                     }
@@ -77,6 +110,14 @@
             }
 
             .statusrow {
+                background-color: #FFFFFF;
+            }
+
+            .statuserrrow:hover {
+                background-color: #e8e8e8;
+            }
+
+            .statuserrrow {
                 background-color: #FFFFFF;
             }
 
@@ -175,9 +216,13 @@
         </style>
     </head>
 
-    <body>
+    <body onload="javascript: collapseGroups();">
         <jsp:include page="header.jsp" />
-        <script type="text/javascript">document.getElementById('status').style.backgroundColor = '#ccccff';</script>
+        <script type="text/javascript">
+        	if (document.getElementById('status') !== null) {
+        		document.getElementById('status').style.backgroundColor = '#ccccff';
+    		}
+		</script>
         <c:if test="${workingCollection != null}">
             <div id="details">
                 <jsp:include page="statusdetails.jsp"/>
@@ -186,7 +231,7 @@
         </c:if>
 
         <div id="searchtable" align="center">
-            <form method="GET" role="form">
+            <form method="GET" role="form" id="searchForm">
                 <div class="input">
                     <span class="input-group-addon">Group</span>
                     <input type="text" class="form-input" id="group-filter"
@@ -250,7 +295,7 @@
 	                    </tr>
 	                </c:if>
 	
-	                <tr class="grouptrerr${item.collection.group}" >
+	                <tr class="statuserrrow grouptrerr${item.collection.group}" >
 	                    <td width="6%" nowrap>
 	
 	                        <c:choose>
@@ -338,38 +383,9 @@
             </thead>
             <c:set var="count" value="0" />
             <jsp:useBean id="today" class="java.util.Date"/>
-            <c:forEach var="item" items="${collections}">
 
-                <c:if test="${currgroup != item.collection.group && item.collection.group != null}">
-                    <c:set var="group" value="${item.collection.group}"/>
-                    <c:set var="group_count" value="${groups[group].count}"/>
-                    <c:set var="size" value="${groups[group].size}"/>
-
-                    <tr>
-                        <td class="groupheader" colspan="3" onclick="toggleVisibility('spexpand${group}','inline'); toggleVisibility('sphide${group}','inline');">
-                        	<div onclick="showGroup('grouptr${group}')" id="spexpand${group}" style="display:none;cursor: pointer;" >
-                        		<span class="lbl-group">[+]</span><span style="margin-left:6px;">${group}</span>
-                        	</div>
-                        	<div onclick="hideGroup('grouptr${group}')" id="sphide${group}" style="display:inline;cursor: pointer;" >
-                        		<span class="lbl-group">[-]</span><span style="margin-left:6px;">${group}</span>
-                        	</div>
-                        </td>
-                        <td class="groupheader" id="group${group}">
-                                ${group_count}
-                        </td>
-                        <td class="groupheader">
-                            <c:choose>
-                                <c:when test="${size > 0}"><d:FileSize value="${size}" /></c:when>
-                                <c:otherwise>0 B</c:otherwise>
-                            </c:choose>
-                        </td>
-                        <td class="groupheader" colspan="3"></td>
-                    </tr>
-                    <c:set var="counttotal" value="0" />
-                    <c:set var="sizetotal" value="0" />
-                </c:if>
-
-                <tr class="statusrow grouptr${item.collection.group}" >
+            <c:forEach var="item" items="${noGroupCollections}">	
+                <tr class="statusrow" >
                     <td width="6%" nowrap>
 
                         <c:choose>
@@ -438,8 +454,112 @@
                     </td>
                     <td nowrap>${item.collection.settings['audit.period']} days</td>
                 </tr>
+
                 <c:set var="count" value="${count + 1}" />
-                <c:set var="currgroup" value="${item.collection.group}" />
+            </c:forEach>
+
+            <c:forEach var="group" items="${colGroups}">
+                <c:set var="group_count" value="${groups[group].count}"/>
+                <c:set var="size" value="${groups[group].size}"/>
+                <c:set var="counttotal" value="0" />
+                <c:set var="sizetotal" value="0" />         
+                <tr class="groupheaderrow${group}">
+                    <td class="groupheader" colspan="3" onclick="toggleVisibility('spexpand${group}','inline'); toggleVisibility('sphide${group}','inline');">
+                    	<div onclick="searchGroup('${group}')" id="spexpand${group}" style="display:none;cursor: pointer;" >
+                    		<span class="lbl-group">[+]</span><span style="margin-left:6px;">${group}</span>
+                    	</div>
+                    	<div onclick="hideGroup('grouptr${group}')" id="sphide${group}" style="display:inline;cursor: pointer;" >
+                    		<span class="lbl-group">[-]</span><span style="margin-left:6px;">${group}</span>
+                    	</div>
+                    </td>
+                    <td class="groupheader" id="group${group}">
+                            ${group_count}
+                    </td>
+                    <td class="groupheader">
+                        <c:choose>
+                            <c:when test="${size > 0}"><d:FileSize value="${size}" /></c:when>
+                            <c:otherwise>0 B</c:otherwise>
+                        </c:choose>
+                    </td>
+                    <td class="groupheader" colspan="3"></td>
+                </tr>
+
+                <c:forEach var="item" items="${collections}">        	
+	                <c:if test="${item.collection.group != null && group == item.collection.group}">
+	
+		                <tr class="statusrow grouptr${item.collection.group}" >
+		                    <td width="6%" nowrap>
+		
+		                        <c:choose>
+		                            <c:when test="${item.fileAuditRunning || item.tokenAuditRunning}">
+		                                <img src="images/running.jpg" title="Audit in progress" alt="running" />
+		                            </c:when>
+		                            <c:when test="${item.queued}">
+		                                <img src="images/queued.jpg" title="Audit is queued" alt="queued" />
+		                            </c:when>
+		                            <c:otherwise>
+		                                <img src="images/stopped.jpg" title="No audit in progress" alt="idle" />
+		                            </c:otherwise>
+		                        </c:choose>
+		                        <c:choose>
+		                            <c:when test="${'A'.bytes[0] == item.collection.state }">
+		                                <img src="images/file-ok.jpg" title="Last audit successful" alt="Last audit successful"/>
+		                            </c:when>
+		                            <c:when test="${'E'.bytes[0] == item.collection.state }">
+		                                <img src="images/error.jpg" title="Collection contains errors" alt="Collection contains errors"/>
+		                            </c:when>
+		                            <c:when test="${'I'.bytes[0] == item.collection.state }">
+		                                <img src="images/error.jpg" title="Last audit was interrupted" alt="Last audit was interrupted"/>
+		                            </c:when>
+		                            <c:otherwise>
+		                                <img src="images/file-bad.jpg" title="Complete audit has not occurred" alt="Complete audit has not occurred"/>
+		                            </c:otherwise>
+		                        </c:choose>
+		                    </td>
+		                    <td width="36%">
+		                        <a href="Status?collectionid=${item.collection.id}&status_group=${group}&page=${page.page}&count=${page.count}">${item.collection.name}</a>
+		                    </td>
+		                    <td>${item.collection.storage}</td>
+		                    <td><h:DefaultValue test="${item.totalFiles > -1}" success="${item.totalFiles}" failure="Unknown" /></td>
+		                    <td>
+		                        <c:choose>
+		                            <c:when test="${item.totalSize > 0}"><d:FileSize value="${item.totalSize}" /></c:when>
+		                            <c:otherwise>0 B</c:otherwise>
+		                        </c:choose>
+		                    </td>
+		                    <td>
+		                        <fmt:formatDate pattern="MMM dd yyyy" value="${item.collection.lastSync}"/>
+		                    </td>
+		                    <td>
+		                        <c:choose>
+		                            <c:when test="${item.fileAuditRunning || item.tokenAuditRunning}">
+		                                In Progress
+		                            </c:when>
+		                            <c:when test="${item.queued}">
+		                                Queued
+		                            </c:when>
+		                            <c:when test="${item.collection.state eq 'R'.charAt(0)}">
+		                                Excluded
+		                            </c:when>
+		                            <c:when test="${item.collection.lastSync == null || item.collection.settings['audit.period'] < 1 || pause.paused}">
+		                                Unknown
+		                            </c:when>
+		                            <c:when test="${today.time > (item.collection.lastSync.time + item.collection.settings['audit.period'] * 1000 * 60 * 60 * 24)}">
+		                                <span style="color: red; font-weight: bold">
+		                                    <d:DateAdd date="${item.collection.lastSync}" format="MMM dd yyyy" period="${item.collection.settings['audit.period']}"/>
+		                                </span>
+		                            </c:when>
+		                            <c:otherwise>
+		                                <d:DateAdd date="${item.collection.lastSync}" format="MMM dd yyyy" period="${item.collection.settings['audit.period']}"/>
+		                            </c:otherwise>
+		                        </c:choose>
+		                    </td>
+		                    <td nowrap>${item.collection.settings['audit.period']} days</td>
+		                </tr>
+
+		                <c:set var="count" value="${count + 1}" />
+	                </c:if>
+                </c:forEach>
             </c:forEach>
 
             <tr><td colspan="5"><br/><d:Auth role="Collection Modify" showUnauthenticated="true"><a href="ManageCollection">Add Collection</a></d:Auth> &nbsp;&nbsp;&nbsp&nbsp;&nbsp;

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -30,6 +30,12 @@
             var grouptr = 'grouptr';
             var statusrow = 'statusrow';
 
+            function search() {
+                document.getElementById('action').value = 'search';
+
+                document.getElementById("searchForm").submit();
+            }
+
             function toggleVisibility(id,type) {
                 var t = document.getElementById(id);
                 var display = t.style.display;
@@ -47,7 +53,7 @@
                     }
                 }
             }
-            function searchGroup(group)
+            function browseGroup(group)
             {
                 document.getElementById('group-filter').value = group;
 
@@ -231,7 +237,7 @@
         </c:if>
 
         <div id="searchtable" align="center">
-            <form method="GET" role="form" id="searchForm">
+            <form method="GET" role="form" id="searchForm" onsubmit="search()">
                 <div class="input">
                     <span class="input-group-addon">Group</span>
                     <input type="text" class="form-input" id="group-filter"
@@ -260,6 +266,7 @@
                 </div>
 
                 <div class="input" align="left">
+                    <input type="hidden" id="action" name="action" value="${action}"/>
                     <button type="submit" class="btn is-secondary" value="Submit"><span>Submit</span></button>
                 </div>
             </form>
@@ -415,7 +422,7 @@
                         </c:choose>
                     </td>
                     <td width="36%">
-                        <a href="Status?collectionid=${item.collection.id}&page=${page.page}&count=${page.count}">${item.collection.name}</a>
+                        <a href="Status?collectionid=${item.collection.id}&page=${page.page}&count=${page.count}&action=${action}">${item.collection.name}</a>
                     </td>
                     <td>${item.collection.storage}</td>
                     <td><h:DefaultValue test="${item.totalFiles > -1}" success="${item.totalFiles}" failure="Unknown" /></td>
@@ -465,7 +472,7 @@
                 <c:set var="sizetotal" value="0" />         
                 <tr class="groupheaderrow${group}">
                     <td class="groupheader" colspan="3" onclick="toggleVisibility('spexpand${group}','inline'); toggleVisibility('sphide${group}','inline');">
-                    	<div onclick="searchGroup('${group}')" id="spexpand${group}" style="display:none;cursor: pointer;" >
+                    	<div onclick="browseGroup('${group}')" id="spexpand${group}" style="display:none;cursor: pointer;" >
                     		<span class="lbl-group">[+]</span><span style="margin-left:6px;">${group}</span>
                     	</div>
                     	<div onclick="hideGroup('grouptr${group}')" id="sphide${group}" style="display:inline;cursor: pointer;" >
@@ -517,7 +524,7 @@
 		                        </c:choose>
 		                    </td>
 		                    <td width="36%">
-		                        <a href="Status?collectionid=${item.collection.id}&status_group=${group}&page=${page.page}&count=${page.count}">${item.collection.name}</a>
+		                        <a href="Status?collectionid=${item.collection.id}&status_group=${group}&page=${page.page}&count=${page.count}&action=${action}">${item.collection.name}</a>
 		                    </td>
 		                    <td>${item.collection.storage}</td>
 		                    <td><h:DefaultValue test="${item.totalFiles > -1}" success="${item.totalFiles}" failure="Unknown" /></td>


### PR DESCRIPTION
Related ticket #5 

Show all Groups collapsed on the first page rather than expanded. 
The behavior and paging of the landing page will be changed:
- Click on the group row will expend the collections in the group and collapse other group, which is like browsing.
- Search will works similar with group collapse, but if searching with group name, the collections in that group will be opened.
- Collections with no or empty groups will display on the top if it meets the search criteria.
- Search by group will get expanded results.

Screenshots:
- Groups collapsed with no error collections
<img width="1440" alt="Screen Shot - ACR collapse no errors" src="https://user-images.githubusercontent.com/2430784/160004652-8d80c531-d7b6-4477-854a-04fc5af2d071.png">

- Groups collapsed with singleton
<img width="1434" alt="Screen Shot - ACE collapse with sigleton" src="https://user-images.githubusercontent.com/2430784/160004760-46d0568f-d578-474e-81ed-e53c4e107cbb.png">

- Groups collapsed with error collections
<img width="1438" alt="Screen Shot - ACE collapse with errors" src="https://user-images.githubusercontent.com/2430784/160004867-4766403a-b26c-4ddf-9929-963a6182f852.png">

- Group expended after clicking on it
<img width="1440" alt="Screen Shot - ACE open with no errors" src="https://user-images.githubusercontent.com/2430784/160458816-4b668c47-51e6-4f45-8d55-f69cba412ce6.png">

- Group expended on search by group
<img width="1440" alt="Screen Shot - ACE search by group" src="https://user-images.githubusercontent.com/2430784/160458905-929b42d2-2bf1-4a93-9db3-775a3ccba0a9.png">
