### PR TITLE
Make clearing a collection more intuitive with a close button.

### DIFF
--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -132,6 +132,17 @@
             {
                 background-color: #e8e8e8;
             }
+            .btn-close
+            {
+                z-index: 101;
+                position: relative;
+                float: right;
+                border: 2px solid #ccc;
+                padding: 3px 6px;
+                background-color: #ddd;
+                opacity: 0.75;
+                cursor: pointer;
+            }
 
             .lbl-group
             {

--- a/ace-am/src/main/webapp/statusdetails.jsp
+++ b/ace-am/src/main/webapp/statusdetails.jsp
@@ -9,8 +9,9 @@
     "http://www.w3.org/TR/html4/loose.dtd">
 
 <c:if test="${workingCollection != null}">
-    <fieldset>
-        <legend>${workingCollection.collection.name} <a href="Status?collectionid=-1">x</a></legend>
+    <fieldset id="col-container">
+        <legend>${workingCollection.collection.name}</legend>
+        <a class="btn-close" onclick="document.getElementById('col-container').style.display='none'">Close</a>
         <table id="detailstbl1">
             <tr>
                 <td>Collection State</td>


### PR DESCRIPTION
Related ticket #6 

Make clearing a collection more intuitive with a close button.
Retain the current page instead of reload the status page after clearing a collection.

Screenshots:
- Before changes (small x)
<img width="1433" alt="Screen Shot - ACE before changes" src="https://user-images.githubusercontent.com/2430784/160496790-bead793f-e05b-4416-a09a-e240d14a6b5a.png">


- Close button
<img width="1440" alt="Screen Shot  - ACE close button" src="https://user-images.githubusercontent.com/2430784/160496167-ce48c0eb-e991-4fc6-aece-82dcae971443.png">

- Before/after click on the close button
<img width="1438" alt="Screen Shot - ACE before and after closed" src="https://user-images.githubusercontent.com/2430784/160496153-ccaa312e-2a3c-41b1-bc86-bd280712b7c2.png">

