### PR TITLE
Upgrade dependency-check-maven to fix the dependency check error.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.1.0</version>
+                <version>7.0.3</version>
                 <configuration>
                     <cveValidForHours>12</cveValidForHours>
                     <failBuildOnCVSS>11</failBuildOnCVSS>


### PR DESCRIPTION
Related ticket #24 

Upgrade dependency-check-maven to fix the dependency check timeout error.
