### PR TITLE
Add indexes to improve query performance.

### DIFF
--- a/ace-am/src/main/sql/1.8-1.8.1.updates.sql
+++ b/ace-am/src/main/sql/1.8-1.8.1.updates.sql
@@ -1,0 +1,4 @@
+create index idx_collection_storage on collection(storage);
+create index idx_collection_name on collection(name);
+create index idx_collection_colgroup on collection(colgroup);
+create index idx_collection_state on collection(state);


### PR DESCRIPTION
Related ticket #19 

Add indexes to improve query performance.

Note: The indexes added is basing on the prod aceamdb schema 
[aceam_schema_no_data_041222.txt](https://github.com/Chronopolis-Digital-Preservation/audit-control-environment/files/8507271/aceam_schema_no_data_041222.txt), and the search parameters that can affect the performance of the query. 
