### PR TITLE
Use breadcrumbs navigation for collections view and pages.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
@@ -72,6 +72,7 @@ public class StatusServlet extends EntityManagerServlet {
 
     // TODO: Add session fields for pagination and search params
     public static final String SESSION_WORKINGCOLLECTION = "workingCollection";
+    public static final String SESSION_COLLECTION_URI = "collectionUri";
 
     private static final String PARAM_CSV = "csv";
 
@@ -333,6 +334,7 @@ public class StatusServlet extends EntityManagerServlet {
         if (Strings.isValidLong(idParam) && -1 == collectionId) {
             // clear the working collection
             request.getSession().removeAttribute(SESSION_WORKINGCOLLECTION);
+            request.getSession().removeAttribute(SESSION_COLLECTION_URI);
         } else if (Strings.isValidLong(idParam)                                            // valid param
                 && (workingCollectionBean == null                                          // no working collection
                 || !workingCollectionBean.getCollection().getId().equals(collectionId))) { // or one which does not equal our requested collection
@@ -341,6 +343,9 @@ public class StatusServlet extends EntityManagerServlet {
             if (workingCollection != null) {
                 workingCollectionBean = createCollectionSummary(workingCollection);
                 request.getSession().setAttribute(SESSION_WORKINGCOLLECTION, workingCollectionBean);
+
+                String collectionUri = request.getRequestURL()+"?"+request.getQueryString();
+                request.getSession().setAttribute(SESSION_COLLECTION_URI, collectionUri);
             }
 
         } else {

--- a/ace-am/src/main/webapp/breadcrumbs.jsp
+++ b/ace-am/src/main/webapp/breadcrumbs.jsp
@@ -38,16 +38,15 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
 <c:set var="lastPath" value="${uriPaths[fn:length(uriPaths)-1]}" />
 <c:set var="pageName">
     <c:choose>
-        <c:when test="${fn:indexOf(lastPath, 'Users') >= 0}">Accounts</c:when>
-        <c:when test="${fn:indexOf(lastPath, 'Statistics') >= 0}">Reporting</c:when>
-        <c:when test="${fn:indexOf(lastPath, 'EventLog') >= 0 && colid != ''}">View Log</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'Users') >= 0}">User Accounts</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'Statistics') >= 0}">Global Ingest Report</c:when>
         <c:when test="${fn:indexOf(lastPath, 'EventLog') >= 0}">Event Log</c:when>
         <c:when test="${fn:indexOf(lastPath, 'UpdateSettings') >= 0}">System Settings</c:when>
         <c:when test="${fn:indexOf(lastPath, 'ManageCollection') >= 0}">Collection Settings</c:when>
         <c:when test="${fn:indexOf(lastPath, 'collectionremove') >= 0}">Remove Collection</c:when>
         <c:when test="${fn:indexOf(lastPath, 'ingest_form') >= 0}">Import Tokens</c:when>
         <c:when test="${fn:indexOf(lastPath, 'ManageFilters') >= 0}">Modify Filters</c:when>
-        <c:when test="${fn:indexOf(lastPath, 'ReportConfiguration') >= 0}">Modify Reporting</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ReportConfiguration') >= 0}">Automated Reports</c:when>
         <c:when test="${fn:indexOf(lastPath, 'compare_form') >= 0}">Compare Collection</c:when>
         <c:when test="${fn:indexOf(lastPath, 'ReportDuplicates') >= 0}">Show Duplicate Files</c:when>
         <c:when test="${fn:indexOf(lastPath, 'ViewSummary') >= 0}">Activity Reports</c:when>

--- a/ace-am/src/main/webapp/breadcrumbs.jsp
+++ b/ace-am/src/main/webapp/breadcrumbs.jsp
@@ -1,0 +1,74 @@
+<%@page contentType="text/html"%>
+<%@page pageEncoding="UTF-8"%>
+<%--
+The taglib directive below imports the JSTL library. If you uncomment it,
+you must also add the JSTL library to the project. The Add Library... action
+on Libraries node in Projects view can be used to add the JSTL 1.1 library.
+--%>
+
+<%@taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%> 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+    "http://www.w3.org/TR/html4/loose.dtd">
+
+<c:set var="colid">
+    <c:choose>
+        <c:when test="${param.collectionid != nul && param.collectionid != ''}">${param.collectionid}</c:when>
+        <c:when test="${param.collection != nul && param.collection != ''}">${param.collection}</c:when>
+        <c:otherwise></c:otherwise>
+    </c:choose>
+</c:set>
+<c:set var="colname">
+    <c:choose>
+        <c:when test="${workingCollection != null}">${workingCollection.collection.name}</c:when>
+        <c:otherwise>${colid}</c:otherwise>
+    </c:choose>
+</c:set>
+
+<c:set var="pageUri">
+    <c:choose>
+        <c:when test="${requestScope['javax.servlet.forward.request_uri'] != null}">
+            ${requestScope['javax.servlet.forward.request_uri']}
+        </c:when>
+        <c:otherwise>${pageContext.request.requestURI}</c:otherwise>
+    </c:choose>
+</c:set>
+<c:set var="uriPaths" value="${fn:split(pageUri, '/')}" />
+<c:set var="lastPath" value="${uriPaths[fn:length(uriPaths)-1]}" />
+<c:set var="pageName">
+    <c:choose>
+        <c:when test="${fn:indexOf(lastPath, 'Users') >= 0}">Accounts</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'Statistics') >= 0}">Reporting</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'EventLog') >= 0 && colid != ''}">View Log</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'EventLog') >= 0}">Event Log</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'UpdateSettings') >= 0}">System Settings</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ManageCollection') >= 0}">Collection Settings</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'collectionremove') >= 0}">Remove Collection</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ingest_form') >= 0}">Import Tokens</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ManageFilters') >= 0}">Modify Filters</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ReportConfiguration') >= 0}">Modify Reporting</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'compare_form') >= 0}">Compare Collection</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ReportDuplicates') >= 0}">Show Duplicate Files</c:when>
+        <c:when test="${fn:indexOf(lastPath, 'ViewSummary') >= 0}">Activity Reports</c:when>
+        <c:when test="${fn:indexOf(lastPath, '.') > 0}">${fn:substringBefore(lastPath, '.')}</c:when>
+        <c:otherwise>${lastPath}</c:otherwise>
+    </c:choose>
+</c:set>
+
+<ol aria-label="Breadcrumb" class="breadcrumb breadcrumbs-list">
+    <li>
+        <a class="nav-link" href="${pageContext.servletContext.contextPath}" style="font-size: 15px;">Home</a>
+    </li>
+
+    <c:if test="${pageName != 'Status' && colid != '' && collectionUri != null}">
+        <li>
+            <a class="nav-link" href="${collectionUri}" style="font-size: 15px;">${colname}</a>
+        </li>
+    </c:if>
+    <c:if test="${fn:endsWith(pageContext.servletContext.contextPath, pageName) == false}">
+        <li>
+            <div class="nav-link" style="color: #666; font-size: 15px;">${pageName}</div>
+        </li>
+    </c:if>
+</ol>

--- a/ace-am/src/main/webapp/header.jsp
+++ b/ace-am/src/main/webapp/header.jsp
@@ -58,3 +58,4 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
 <div class="header">
     <img src="images/title.jpg" alt="ACE Audit Manager"><BR><div style="font-size: large; color: red">${globalMessage}</div>
 </div>
+<jsp:include page="breadcrumbs.jsp" />

--- a/ace-am/src/main/webapp/report.jsp
+++ b/ace-am/src/main/webapp/report.jsp
@@ -75,13 +75,17 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
             margin-right: 24px;
         }
 
+        .container {
+            width: 94%;
+            margin-bottom: 20px;
+        }
     </style>
 </head>
 <body>
 <jsp:include page="header.jsp"/>
 <jsp:useBean id="collection" scope="request"
              type="edu.umiacs.ace.monitor.access.CollectionSummaryBean"/>
-<div class="container" style="width: 90%; margin-bottom: 20px;">
+<div class="container">
   <table id="summaryTable">
     <tr>
         <td class="lblTd">Active Files</td>
@@ -152,7 +156,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 </div>
 
 <form method="GET" action="RemoveItem">
-    <div class="container" style="width: 90%">
+    <div class="container">
         <um:Auth role="Remove Item">
         <span>Select All:&nbsp;</span> <input type="checkbox" id="selectall"/>
         </um:Auth>

--- a/ace-am/src/main/webapp/statusdetails.jsp
+++ b/ace-am/src/main/webapp/statusdetails.jsp
@@ -177,8 +177,8 @@
                         <c:if test="${workingCollection.collection.state ne 'R'.charAt(0) && (!(workingCollection.fileAuditRunning || workingCollection.tokenAuditRunning || workingCollection.queued))}">
                             <um:Auth role="Collection Modify">
                                 <a href="ManageCollection?collectionid=${workingCollection.collection.id}" title="Configure connection settings for this collection" >Collection Settings</a><br>
-                                <a href="collectionremove.jsp" title="Delete Collection">Remove Collection</a><br>
-                                <a href="ingest_form.jsp" title="Import Tokens">Import Tokens</a><br>
+                                <a href="collectionremove.jsp?collectionid=${workingCollection.collection.id}" title="Delete Collection">Remove Collection</a><br>
+                                <a href="ingest_form.jsp?collectionid=${workingCollection.collection.id}" title="Import Tokens">Import Tokens</a><br>
                                 <a href="ManageFilters?collectionid=${workingCollection.collection.id}">Modify Filters</a><BR>                                
                             </um:Auth>
                             <um:Auth role="Modify Activity Reporting">
@@ -196,7 +196,7 @@
 	                        </um:Auth>
                         </c:if>
                         <um:Auth role="Compare">
-                            <a href="compare_form.jsp">Compare Collection</a><br>
+                            <a href="compare_form.jsp?collectionid=${workingCollection.collection.id}">Compare Collection</a><br>
                         </um:Auth>
                         <um:Auth role="Show Duplicates">
                             <a href="ReportDuplicates?collectionid=${workingCollection.collection.id}">Show Duplicate Files</a>

--- a/ace-am/src/main/webapp/style.css
+++ b/ace-am/src/main/webapp/style.css
@@ -53,7 +53,7 @@ ul {
 
 .nav-link {
     display: block;
-    padding: .5em 1em;
+    padding: .5em 0.5em;
 }
 
 .justify-content-center {
@@ -433,4 +433,29 @@ vertical-align: top;
     background-color: #ddd;
     opacity: 0.75;
     cursor: pointer;
+}
+
+.breadcrumb
+{
+    list-style: none;
+    border-radius: 4px;
+    background-color: #ffffff;
+    margin-bottom: 0px !important;
+    padding: 0px 40px !important;
+    margin-bottom: 12px !important;
+}
+
+ol, ol li
+{
+    list-style-type:decimal;
+    padding: 0px;
+    margin: 0px;
+    display: flex;
+}
+
+.breadcrumb>li+li:before
+{
+    content: "/";
+    color: #bbb;
+    margin-top: 8px;
 }


### PR DESCRIPTION
Related to ticket #18 

Use breadcrumbs to navigate and track collections view and pages.

Screenshots for breadcrumbs:
- Home page:
<img width="1438" alt="Screen Shot - ACE breadcrumbs Home" src="https://user-images.githubusercontent.com/2430784/166074054-fc8e4cbe-e2d1-46e2-880a-50d3bb9bd722.png">


- Status page:
<img width="1440" alt="Screen Shot - ACE breadcrumbs Status" src="https://user-images.githubusercontent.com/2430784/166072472-842302a9-5ba3-40f3-8f60-5872e4ba1be0.png">


- Collections view log:
<img width="1440" alt="Screen Shot - ACE breadcrumbs Collection View Log" src="https://user-images.githubusercontent.com/2430784/166073861-337fe54d-4c51-4841-999b-bf892966fc38.png">


- Collection browse:
<img width="1439" alt="Screen Shot - ACE breadcrumbs Collection Browse" src="https://user-images.githubusercontent.com/2430784/166072518-66842031-1714-45bf-92ad-ee9775179136.png">


- Collections report:
<img width="1440" alt="Screen Shot - ACE breadcrumbs Collection Report" src="https://user-images.githubusercontent.com/2430784/166073397-165aca7d-50cb-4916-977e-01b6a827bf81.png">


-  Collection settings:
<img width="1440" alt="Screen Shot - ACE breadcrumbs Collection Settings" src="https://user-images.githubusercontent.com/2430784/166072738-7cbfeffe-b8cf-430d-a174-21cf66e90a6e.png">


- System Settings page
<img width="1440" alt="Screen Shot - ACE breadcrumbs System Settings" src="https://user-images.githubusercontent.com/2430784/166072834-5e52f7f6-ab0b-436d-9f77-c0bce12ad7da.png">


- Accounts page:
<img width="1440" alt="Screen Shot - ACE breadcrumbs Accounts" src="https://user-images.githubusercontent.com/2430784/166072912-f9ac08a8-872f-4c66-bd86-72f790cd9fa1.png">


- Reporting page:
<img width="1439" alt="Screen Shot - ACE breadcrumbs Reporting" src="https://user-images.githubusercontent.com/2430784/166073095-30468668-5893-44c3-87a5-63e9d2688cd2.png">
