### PR TITLE
Add/update H1 headers and page titles, adjusted style for consistency

### DIFF
--- a/ace-am/src/main/webapp/breadcrumbs.jsp
+++ b/ace-am/src/main/webapp/breadcrumbs.jsp
@@ -36,7 +36,7 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
 </c:set>
 <c:set var="uriPaths" value="${fn:split(pageUri, '/')}" />
 <c:set var="lastPath" value="${uriPaths[fn:length(uriPaths)-1]}" />
-<c:set var="pageName">
+<c:set var="pageHeader" scope="request">
     <c:choose>
         <c:when test="${fn:indexOf(lastPath, 'Users') >= 0}">User Accounts</c:when>
         <c:when test="${fn:indexOf(lastPath, 'Statistics') >= 0}">Global Ingest Report</c:when>
@@ -65,9 +65,9 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
             <a class="nav-link" href="${collectionUri}" style="font-size: 15px;">${colname}</a>
         </li>
     </c:if>
-    <c:if test="${fn:endsWith(pageContext.servletContext.contextPath, pageName) == false}">
+    <c:if test="${fn:endsWith(pageContext.servletContext.contextPath, pageHeader) == false}">
         <li>
-            <div class="nav-link" style="color: #666; font-size: 15px;">${pageName}</div>
+            <div class="nav-link" style="color: #666; font-size: 15px;">${pageHeader}</div>
         </li>
     </c:if>
 </ol>

--- a/ace-am/src/main/webapp/browse.jsp
+++ b/ace-am/src/main/webapp/browse.jsp
@@ -18,7 +18,7 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Browse Collection</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <script type="text/javascript" SRC="srbFunctions.js" ></script>
         <style type="text/css">
@@ -115,7 +115,8 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
     <body>
 
         <jsp:include page="header.jsp" />
-
+        <h1 class="page_header">${pageHeader}</h1>
+ 
         <div id="collectionHeader">
             <div class="container">
                 <p class="heading is-centered">Group</p>

--- a/ace-am/src/main/webapp/collectionmodify.jsp
+++ b/ace-am/src/main/webapp/collectionmodify.jsp
@@ -12,7 +12,7 @@ Author     : toaster
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Create/Update Resource</title>
+    <title>${pageHeader}</title>
     <link rel="stylesheet" type="text/css" href="style.css" />
     <script language="javascript">
         isclicked = false;
@@ -52,6 +52,8 @@ Author     : toaster
 </head>
 <body>
 <jsp:include page="header.jsp" />
+<h1 class="page_header">${pageHeader}</h1>
+
 <div class="standardBody">
 <form action="ManageCollection" method="post">
     <c:choose>

--- a/ace-am/src/main/webapp/collectionremove.jsp
+++ b/ace-am/src/main/webapp/collectionremove.jsp
@@ -11,11 +11,13 @@ Author     : toaster
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Collection Remove</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
     </head>
     <body>
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+
         <div class="standardBody">
         <h3>Confirm Remove</h3>
             <p>

--- a/ace-am/src/main/webapp/compare_form.jsp
+++ b/ace-am/src/main/webapp/compare_form.jsp
@@ -18,7 +18,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title>Compare Collection</title>
+    <title>${pageHeader}</title>
     <link rel="stylesheet" type="text/css" href="style.css"/>
     <style>
         #compareOr {
@@ -108,6 +108,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 </head>
 <body>
 <jsp:include page="header.jsp"/>
+<h1 class="page_header">${pageHeader}</h1>
+
 <div class="standardBody">
     <h3 class="standardHeader" id="compareCollectionHeader">Report Collection Differences
         for ${workingCollection.collection.name}</h3>

--- a/ace-am/src/main/webapp/duplicatereport.jsp
+++ b/ace-am/src/main/webapp/duplicatereport.jsp
@@ -18,7 +18,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Identical Files</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <style type="text/css">
             .digest {
@@ -29,6 +29,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     </head>
     <body>
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+
         <div class="standardBody">
             Total Files: ${totalfiles} Duplicate Files: ${totaldups} <fmt:formatNumber maxFractionDigits="2" type="number" value="${(totaldups / totalfiles) * 100}" />% Generation time: ${time}ms
             <table>

--- a/ace-am/src/main/webapp/eventlog.jsp
+++ b/ace-am/src/main/webapp/eventlog.jsp
@@ -10,7 +10,10 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Activity Log</title>
+        <title>${pageHeader}</title>
+
+        <jsp:include page="imports.jsp"/>
+ 
         <script type="text/javascript">
             var scrollDivHeight = 420;
 
@@ -63,8 +66,6 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
         }
         </script>
 
-        <link rel="stylesheet" type="text/css" href="bootstrap.min.css" />
-        <link rel="stylesheet" type="text/css" href="style.css" />
         <style type="text/css">
             #logtypeselection
             {
@@ -202,6 +203,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
             </div>
         </div> 
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+ 
         <script type="text/javascript">if(document.getElementById('log')!=undefined){document.getElementById('log').style.backgroundColor = '#ccccff';}</script>
         
         <div align="center">

--- a/ace-am/src/main/webapp/imports.jsp
+++ b/ace-am/src/main/webapp/imports.jsp
@@ -1,5 +1,2 @@
-<link rel="stylesheet"
-      href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css"
-      integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB"
-      crossorigin="anonymous">
+<link rel="stylesheet" type="text/css" href="bootstrap.min.css" />
 <link rel="stylesheet" type="text/css" href="style.css"/>

--- a/ace-am/src/main/webapp/ingest_form.jsp
+++ b/ace-am/src/main/webapp/ingest_form.jsp
@@ -12,7 +12,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>Ingest Tokens</title>
+    <title>${pageHeader}</title>
     <jsp:include page="imports.jsp"/>
     <style type="text/css">
         button.btn {
@@ -22,8 +22,9 @@
 </head>
 <body>
 <jsp:include page="header.jsp"/>
+<h1 class="page_header">${pageHeader}</h1>
+
 <div class="standardBody">
-    <h4>Import Tokens</h4>
     <h6>
         Working Collection is ${workingCollection.collection.group} -
         ${workingCollection.collection.name}

--- a/ace-am/src/main/webapp/managefilters.jsp
+++ b/ace-am/src/main/webapp/managefilters.jsp
@@ -22,7 +22,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Modify Collection Filters</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <script type="text/javascript" src="jquery-1.7.1.min.js"></script>
         <script type="text/javascript">
@@ -63,6 +63,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     </head>
     <body>
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+
         <div class="standardBody">
 
             <h3>Filters for files in '${collection.name}'</h3>

--- a/ace-am/src/main/webapp/report.jsp
+++ b/ace-am/src/main/webapp/report.jsp
@@ -18,7 +18,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title>Collection Errors</title>
+    <title>${pageHeader}</title>
     <jsp:include page="imports.jsp"/>
 
     <style type="text/css">
@@ -83,6 +83,8 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 </head>
 <body>
 <jsp:include page="header.jsp"/>
+<h1 class="page_header">${pageHeader}</h1>
+
 <jsp:useBean id="collection" scope="request"
              type="edu.umiacs.ace.monitor.access.CollectionSummaryBean"/>
 <div class="container">

--- a/ace-am/src/main/webapp/reportpolicy.jsp
+++ b/ace-am/src/main/webapp/reportpolicy.jsp
@@ -13,7 +13,7 @@ Author     : toaster
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Configure Automated Reporting</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <script language="javascript">
             function checkAll(field)
@@ -47,6 +47,8 @@ Author     : toaster
     </head>
     <body>
         <jsp:include page="header.jsp"/>
+        <h1 class="page_header">${pageHeader}</h1>
+ 
         <div class="standardBody">
             <h3>Add/Modify an automated report</h3>
             

--- a/ace-am/src/main/webapp/settings.jsp
+++ b/ace-am/src/main/webapp/settings.jsp
@@ -14,7 +14,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <title>System Settings</title>
+    <title>${pageHeader}</title>
     <link rel="stylesheet" type="text/css" href="style.css"/>
     <style type="text/css">
         body {
@@ -26,10 +26,11 @@
 </head>
 <body>
 <jsp:include page="header.jsp"/>
+<h1 class="page_header">${pageHeader}</h1>
+
 <FORM name="settingsform" METHOD="POST" ENCTYPE="multipart/form-data" ACTION="UpdateSettings">
   <div align="center">
     <fieldset id="settingsTable">
-        <legend class="form-legend">System Settings</legend>
         <div class="tabs">
             <ul>
                 <li class="is-active" aria-controls="general-settings"><a>General</a></li>

--- a/ace-am/src/main/webapp/statistics.jsp
+++ b/ace-am/src/main/webapp/statistics.jsp
@@ -5,7 +5,7 @@
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <jsp:include page="imports.jsp"/>
-    <title>Collection Ingest Reporting</title>
+    <title>${pageHeader}</title>
 
     <style type="text/css">
         /**
@@ -47,7 +47,8 @@
 </head>
 <body>
 <jsp:include page="header.jsp"/>
-<h3 style="text-align: center;">Collection Ingestion Report</h3>
+<h1 class="page_header">${pageHeader}</h1>
+
 <div align="center">
     <div id="searchtable">
         <form method="POST" role="form">

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -23,7 +23,7 @@
         </c:choose>
 
 
-        <title>ACE Audit Manager</title>
+        <title>${pageHeader}</title>
         <script type="text/javascript" SRC="srbFunctions.js" ></script>
         <script type="text/javascript">
             var groupheaderrow = 'groupheaderrow';
@@ -272,6 +272,8 @@
 
     <body onload="javascript: collapseGroups();">
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+ 
         <script type="text/javascript">
         	if (document.getElementById('status') !== null) {
         		document.getElementById('status').style.backgroundColor = '#ccccff';

--- a/ace-am/src/main/webapp/style.css
+++ b/ace-am/src/main/webapp/style.css
@@ -11,6 +11,10 @@ h1 {
     margin-top: 0.25em;
     margin-bottom: 20px;
     margin-left: 10px;
+    font-family: Arial, Helvetica, sans-serif;
+    font-weight: 500;
+    line-height: 1.1;
+    font-size: 32px;
 }
 
 a:link, a:visited {
@@ -39,6 +43,13 @@ input {
 ul {
     margin-top: 0;
     margin-bottom: 1rem;
+}
+
+.page_header {
+    margin-top: -20px !important;
+    margin-left: 0px !important;
+    text-align: center;
+    color: #666;
 }
 
 .nav {

--- a/ace-am/src/main/webapp/usermodify.jsp
+++ b/ace-am/src/main/webapp/usermodify.jsp
@@ -12,7 +12,7 @@ Author     : toaster
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-        <title>Create/Update Users</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <style type="text/css">
             #error {
@@ -31,6 +31,8 @@ Author     : toaster
     </head>
     <body>
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+        
         <script type="text/javascript">document.getElementById('users').style.backgroundColor = '#ccccff';</script>
         <div class="standardBody">
 

--- a/ace-am/src/main/webapp/viewsummary.jsp
+++ b/ace-am/src/main/webapp/viewsummary.jsp
@@ -17,7 +17,7 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
 
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <title>Summary Reports</title>
+        <title>${pageHeader}</title>
         <link rel="stylesheet" type="text/css" href="style.css" />
         <c:choose>
             <c:when test="${coll != null}">
@@ -90,6 +90,8 @@ on Libraries node in Projects view can be used to add the JSTL 1.1 library.
     </head>
     <body>
         <jsp:include page="header.jsp" />
+        <h1 class="page_header">${pageHeader}</h1>
+ 
         <div class="standardBody">
             <c:choose>
                 <c:when test="${coll != null}">


### PR DESCRIPTION
Related to ticket #42

Add/update page headers and titles, make them consistent with breadcrumbs. and adjusted styles that is affected by bootstrap.

Screenshots:
- Status page
<img width="1440" alt="Screen Shot - ACE h1 header Status" src="https://user-images.githubusercontent.com/2430784/166556513-45ee3a97-2c2d-41a4-9735-475e460dc81d.png">

- Event Log
<img width="1437" alt="Screen Shot - ACE h1 header Event Log" src="https://user-images.githubusercontent.com/2430784/166556689-34add6bf-9953-4091-b4a5-8f89ba2b629d.png">

- Collection Event Log
<img width="1440" alt="Screen Shot - ACE h1 header Collection Event Log" src="https://user-images.githubusercontent.com/2430784/166557010-4bfe41d9-455c-4d54-99cb-120575251daa.png">

- Accounts
<img width="1440" alt="Screen Shot - ACE h1 header Accounts" src="https://user-images.githubusercontent.com/2430784/166557098-73599f13-d940-4b13-a898-4d4fce19ecc1.png">

- System Settings
<img width="1439" alt="Screen Shot - ACE h1 header System Settings" src="https://user-images.githubusercontent.com/2430784/166557180-505c574e-e3bc-4567-a4ce-8835fee53e5f.png">

- Reporting
<img width="1438" alt="Screen Shot - ACE h1 header Reporting" src="https://user-images.githubusercontent.com/2430784/166557293-7afcd227-d17d-4f67-9ac1-42a73d4a361e.png">

- Collection Report
<img width="1440" alt="Screen Shot - ACE h1 header Collection Report" src="https://user-images.githubusercontent.com/2430784/166557595-d528ec76-f5d2-4485-abe2-39416bbbb728.png">

- Browse
<img width="1440" alt="Screen Shot - ACE h1 header Browse" src="https://user-images.githubusercontent.com/2430784/166557787-cbbf5945-70c9-4e09-8515-9203cf17d4d3.png">

- Collection Settings
<img width="1440" alt="Screen Shot - ACE h1 header Collection Settings" src="https://user-images.githubusercontent.com/2430784/166557674-6bc1651e-ec84-489b-8e0d-9267d189788f.png">




