### PR TITLE
Update page title and remove ace-am H1 header from home page.

### DIFF
--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -4,6 +4,7 @@
 <%@taglib tagdir="/WEB-INF/tags" prefix="h" %>
 <%@taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt" %>
 <%@taglib uri="/WEB-INF/tlds/monitor" prefix="d"%>
+<%@taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn"%>
 
 <!DOCTYPE html
     PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
@@ -21,9 +22,16 @@
                 <meta http-equiv="refresh" content="600"/>
             </c:otherwise>
         </c:choose>
-
-
-        <title>${pageHeader}</title>
+        <title>
+            <c:choose>
+                <c:when test="${fn:endsWith(pageContext.servletContext.contextPath, pageHeader) == false}">
+                    ACE Audit Manager
+                </c:when>
+                <c:otherwise>
+                    ${pageHeader}
+                </c:otherwise>
+            </c:choose> 
+        </title>
         <script type="text/javascript" SRC="srbFunctions.js" ></script>
         <script type="text/javascript">
             var groupheaderrow = 'groupheaderrow';
@@ -272,7 +280,9 @@
 
     <body onload="javascript: collapseGroups();">
         <jsp:include page="header.jsp" />
-        <h1 class="page_header">${pageHeader}</h1>
+        <c:if test="${fn:endsWith(pageContext.servletContext.contextPath, pageHeader) == false}">
+            <h1 class="page_header">${pageHeader}</h1>
+        </c:if>
  
         <script type="text/javascript">
         	if (document.getElementById('status') !== null) {


### PR DESCRIPTION
Related to #42

Update page title to "ACE Audit Manager" for Home page and remove the erroneous "ace-am" H1 header for root url "/ace-am".
Note: This won't change the header for "/Status" page, which will still have its H1 header as "Status".

Screenshots:
- Before changes
<img width="1440" alt="Screen Shot - ACE Home before changed" src="https://user-images.githubusercontent.com/2430784/167194892-71c4cede-ea95-46c8-8578-d37265b1a0cc.png">


- After changes
<img width="1440" alt="Screen Shot - ACE Home after changed" src="https://user-images.githubusercontent.com/2430784/167194296-1c6dcccb-aa33-470a-b9af-9b9f3509a3a2.png">

- H1 header for Status page
<img width="1440" alt="Screen Shot  - ACE Header Status page" src="https://user-images.githubusercontent.com/2430784/167501142-5ffa8480-c438-484d-8c6f-504c57d150d3.png">

