### PR TITLE
Table striping for Status page and Event Log page.

### DIFF
--- a/ace-am/src/main/webapp/eventlog.jsp
+++ b/ace-am/src/main/webapp/eventlog.jsp
@@ -109,7 +109,9 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                 background: #e8e8e8;
             }
             .logItem {
-                border-top: 1px solid #000000;
+                border-top: 1px solid #dee2e6;
+                padding-top: 4px;
+                padding-bottom: 4px;
                 width: 100%;
                 cursor: pointer;
                 text-align: left;
@@ -127,16 +129,16 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                 overflow-y: scroll;
             }
             .col-md-padding {
-                padding-left: 8px !important;
-                padding-right: 8px !important;
+                padding-left: 6px !important;
+                padding-right: 6px !important;
             }
             .col-md-left-padding {
-                padding-left: 4px !important;
-                padding-right: 8px !important;
+                padding-left: 3px !important;
+                padding-right: 6px !important;
             }
             .col-md-right-padding {
-                padding-left: 8px !important;
-                padding-right: 4px !important;
+                padding-left: 6px !important;
+                padding-right: 3px !important;
             }
 
             /* event log overlay */
@@ -183,6 +185,18 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                 max-height: 560px;
                 overflow: auto;
                 padding-left: 30px;
+            }
+            .logItem:hover
+            {
+                background-color: #F2FBFF;
+            }
+            .row-strip-highlighted
+            {
+                background-color: #f5f5f5;
+            }
+            .row-strip-normal
+            {
+                background-color: #FFF;
             }
 
             /* scrollbar */
@@ -268,9 +282,9 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
           <div id="log" class="container log">
             <div class="row logHeader">
                 <div class="col-md-1 col-md-left-padding">ID</div>
-                <div class="col-md-5 col-md-padding">
+                <div class="col-md-5 col-md-left-padding">
                     <div class="row">
-                        <div class="col-md-8">Date</div>
+                        <div class="col-md-8 col-md-left-padding">Date</div>
                         <div class="col-md-4 col-md-left-padding">Session</div>
                     </div>
                 </div>
@@ -282,18 +296,23 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                 </div>
             </div>
             <c:if test="${loglist != null}">
-                <c:forEach var="item" items="${loglist}">
-                    <div id="logEntries-${item.id}" class="row logItem"
+                <c:forEach var="item" items="${loglist}" varStatus="loop">
+        	        <c:set var="stripclass">
+            	        <c:choose>
+            	            <c:when test="${loop.index % 2 == 0}">row-strip-highlighted</c:when>
+            	            <c:otherwise>row-strip-highnormal</c:otherwise>
+            	        </c:choose>
+            	    </c:set>
+
+                    <div id="logEntries-${item.id}" class="row logItem ${stripclass}"
                          onclick='javascript:toggleVisibility(${item.id})'
-                         onmouseover='javascript:this.style.background="#e8e8e8"' 
-                         onmouseout='javascript:this.style.background="#ffffff"'
                          >
                         <div class="col-md-1 col-md-left-padding">
                             <span class="info">${item.id}</span>
                         </div>
-                        <div class="col-md-5 col-md-padding">
+                        <div class="col-md-5 col-md-left-padding">
                             <div class="row">
-                                <div class="col-md-8">
+                                <div class="col-md-8 col-md-left-padding">
                                     <span class="info">${item.date}</span>
                                 </div>
                                 <div class="col-md-4 col-md-left-padding">

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -248,8 +248,12 @@
             }
 			#statustable td, #statustable-errors td
             {
-            	padding-top: 3px !important;
-            	padding-bottom: 3px !important;
+            	padding-top: 4px !important;
+            	padding-bottom: 4px !important;
+            }
+            tr.statusrow td, tr.statuserrrow td
+            {
+                border-bottom: 1px solid #dee2e6;
             }
             #statustable thead, #statustable-errors thead
             {
@@ -266,6 +270,14 @@
             	width: 100%;
             	background-color: #F2FBFF;
             	font-weight: normal;
+            }
+            .row-strip-highlighted
+            {
+                background-color: #F5f5f5;
+            }
+            .row-strip-normal
+            {
+                background-color: #FFF;
             }
         </style>
     </head>
@@ -337,6 +349,12 @@
 	            <c:forEach var="item" items="${errorCollections}" varStatus="loop">
 	                <c:if test="${currErrGroup != item.collection.group || loop.index == 0}">
 	                	<c:set var="errgroup" value="${item.collection.group}"/>
+	                	<c:set var="stripclasserrors">
+	                	    <c:choose>
+	                	        <c:when test="${stripclasserrors.index % 2 == 0}">row-strip-highlighted</c:when>
+	                	        <c:otherwise>row-strip-highnormal</c:otherwise>
+	                	    </c:choose>
+	                	</c:set>
 	                	
 	                	<!-- close the collection group table -->
 	                	<c:if test="${loop.index > 0}">
@@ -359,9 +377,9 @@
 	                    </tr>
 
 	                    <tr class="grouptrerr${errgroup}">
-	                        <td colspan="3">
-	                          <div  style="margin-left:16px;margin-left:18px;">
-	                            <table id="statustable-errors-group">
+	                        <td colspan="3" style="border-bottom: none;">
+	                          <div  style="margin: 8px 4px 8px 16px;">
+	                            <table id="statustable-errors-group" border="0" cellpadding="0" cellspacing="0">
 	                              <thead>
 	                                <td width="4%" nowrap>Audit</td>
 	                                <td width="6%" nowrap>Status</td>
@@ -377,7 +395,7 @@
 	                    </tr>
 	                </c:if>
 
-	                <tr class="statuserrrow grouptrerr${item.collection.group}" >
+	                <tr class="statuserrrow ${stripclasserrors} grouptrerr${item.collection.group}">
 	                    <td nowrap>
 	
 	                        <c:choose>
@@ -497,9 +515,9 @@
                 </tr>
 
                 <tr class="statusrow groupexpanded grouptr${group}">
-                    <td colspan="3">
-                      <div  style="margin-left:16px;margin-left:18px;">
-                        <table id="statustable-group">
+                    <td colspan="3" style="border-bottom: none;">
+                      <div  style="margin: 8px 4px 8px 16px;">
+                        <table id="statustable-group" border="0" cellpadding="0" cellspacing="0">
                           <thead>
                             <td width="4%" nowrap>Audit</td>
                             <td width="6%" nowrap>Status</td>
@@ -514,10 +532,17 @@
                     </td>
                 </tr>
 	                
-                <c:forEach var="item" items="${collections}">        	
+                <c:forEach var="item" items="${collections}" varStatus="loopcollections">
+        	        <c:set var="stripclasscollections">
+            	        <c:choose>
+            	            <c:when test="${loopcollections.index % 2 == 0}">row-strip-highlighted</c:when>
+            	            <c:otherwise>row-strip-highnormal</c:otherwise>
+            	        </c:choose>
+            	    </c:set>       	
+
 	                <c:if test="${item.collection.group != null && group == item.collection.group}">
 	
-		                <tr class="statusrow grouptr${item.collection.group}" >
+		                <tr class="statusrow ${stripclasscollections} grouptr${item.collection.group}" >
 		                    <td width="6%" nowrap>
 		
 		                        <c:choose>
@@ -614,10 +639,10 @@
                 </td>
                 <td class="groupheader"></td>
               </tr>
-              <tr class="statusrow grouptrnogroup">
+              <tr class="statusrow grouptrnogroup" style="border-bottom: none;">
                 <td colspan="3">
-                  <div  style="margin-left:16px;margin-left:18px;">
-                    <table id="statustable-group">
+                  <div  style="margin: 8px 4px 8px 16px;">
+                    <table id="statustable-group" border="0" cellpadding="0" cellspacing="0">
                       <thead>
                         <td width="4%" nowrap>Audit</td>
                         <td width="6%" nowrap>Status</td>
@@ -632,8 +657,15 @@
                 </td>
               </tr>
 
-              <c:forEach var="item" items="${noGroupCollections}">	
-                <tr class="statusrow grouptrnogroup">
+              <c:forEach var="item" items="${noGroupCollections}" varStatus="loopnogroups">
+        	    <c:set var="stripclassnogroups">
+            	    <c:choose>
+            	        <c:when test="${loopnogroups.index % 2 == 0}">row-strip-highlighted</c:when>
+            	        <c:otherwise>row-strip-highnormal</c:otherwise>
+            	    </c:choose>
+            	</c:set>	
+
+                <tr class="statusrow stripclassnogroups grouptrnogroup">
                     <td>
 
                         <c:choose>


### PR DESCRIPTION
Related to #40 

Table striping for Status page and Event Log page.

Screenshots:
- Status expanded collection table
<img width="1440" alt="Screen Shot - ACE table strip Status" src="https://user-images.githubusercontent.com/2430784/167926913-fe5b6387-41da-4519-9f17-c7ea10e23780.png">


- Event Log
<img width="1440" alt="Screen Shot - ACE table strip Event Log" src="https://user-images.githubusercontent.com/2430784/167926944-d9851ba4-d26d-448b-a2e5-36c896012eac.png">
