### PR TITLE
Add Removals category to refine ROMVED collections events in event log.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogCategoryHandler.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogCategoryHandler.java
@@ -87,6 +87,9 @@ public class LogCategoryHandler extends SimpleTagSupport {
             case LogEvent.CHOICE_SYNC:
                 label = "Sync Start/Stop Events";
                 break;
+            case LogEvent.CHOICE_REMOVALS:
+                label = "Removals";
+                break;
             default:
                 label = category;
                 break;

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogEnum.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogEnum.java
@@ -157,6 +157,8 @@ public enum LogEnum {
 	            || logType == LogEnum.FILE_AUDIT_CANCEL.getType()
                 || logType == LogEnum.FILE_AUDIT_ABORT.getType()) {
             category = LogEvent.CHOICE_SYNC;
+        } else if (logType == LogEnum.COLLECTION_REMOVED.getType()) {
+            category = LogEvent.CHOICE_REMOVALS;
         }
 
         return category;

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogEvent.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogEvent.java
@@ -61,6 +61,7 @@ public class LogEvent implements Serializable {
     public static final String CHOICE_MISSING = "missing";
     public static final String CHOICE_NEWMASTER = "newmaster";
     public static final String CHOICE_SYNC = "sync";
+    public static final String CHOICE_REMOVALS = "removals";
 
     private static final long serialVersionUID = 1L;
     @Id

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/log/LogServlet.java
@@ -336,6 +336,8 @@ public class LogServlet extends EntityManagerServlet {
                 returnString.append(LogEnum.FILE_AUDIT_START.getType()).append(",");
                 returnString.append(LogEnum.FILE_AUDIT_CANCEL.getType()).append(",");
                 returnString.append(LogEnum.FILE_AUDIT_ABORT.getType()).append(",");
+            } else if ( LogEvent.CHOICE_REMOVALS.equals(key) ) {
+                returnString.append(LogEnum.COLLECTION_REMOVED.getType()).append(",");
             }
         }
 
@@ -408,7 +410,13 @@ public class LogServlet extends EntityManagerServlet {
                 map.put(LogEvent.CHOICE_SYNC, "checked");
             }
         }
-
+        else if ( LogEvent.CHOICE_REMOVALS.equals(toggleType) ) {
+            if ( map.containsKey(LogEvent.CHOICE_REMOVALS) ) {
+                map.remove(LogEvent.CHOICE_REMOVALS);
+            } else {
+                map.put(LogEvent.CHOICE_REMOVALS, "checked");
+            }
+        }
         return map;
     }
 }

--- a/ace-am/src/main/webapp/eventlog.jsp
+++ b/ace-am/src/main/webapp/eventlog.jsp
@@ -262,6 +262,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
             
             <tr>
                 <td>Show Only:</td>
+                <td align="center"><b>Removals</b></td>
                 <td align="center"><b>System Errors</b></td>
                 <td align="center"><b>Monitored File Errors</b></td>
                 <td align="center"><b>New Master Items</b></td> 
@@ -271,6 +272,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
             
             <tr>
                 <td></td>
+                <td align="center"><input onClick="javascript:toggleSelected('removals'); return false;" ${selects['removals']} type="checkbox" style="border:none"/></td>
                 <td align="center"><input onClick="javascript:toggleSelected('errors'); return false;" ${selects['errors']} type="checkbox" style="border:none"/></td>
                 <td align="center"><input onClick="javascript:toggleSelected('missing'); return false;" ${selects['missing']} type="checkbox" style="border:none"/></td>
                 <td align="center"><input onClick="javascript:toggleSelected('newmaster'); return false;" ${selects['newmaster']} type="checkbox" style="border:none"/></td>


### PR DESCRIPTION
Related to #43 

Add `Removals` category to refine ROMVED collections events in event log, which will help on finding all REMOVED collections.

Screenshots:
-  Event Log with Removals category (not checked)
<img width="1440" alt="Screen Shot  - ACE Event Log Removals not checked" src="https://user-images.githubusercontent.com/2430784/169148147-619aa01c-28ca-43b7-a545-da5e69ce99e0.png">

- Event Log with Removals category checked
<img width="1440" alt="Screen Shot  - ACE Event Log Removals checked" src="https://user-images.githubusercontent.com/2430784/169150100-5eada26d-2b35-4934-9f09-e3a07f213809.png">

