### PR TITLE
Chron dashboard json output.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
@@ -169,7 +169,7 @@ public class StatusServlet extends EntityManagerServlet {
         collectionGroups = new ArrayList<>();
         noGroupCollections = new ArrayList<>();
 
-        if (queries.size() > 0 || action != null && action.trim().equalsIgnoreCase(ACTION_SEARCH)) {
+        if (hasJson(request) || queries.size() > 0 || action != null && action.trim().equalsIgnoreCase(ACTION_SEARCH)) {
         	// Query collections
             queryString.append("SELECT c FROM Collection c");
             countString.append("SELECT COUNT(c.id) FROM Collection c");

--- a/ace-am/src/main/webapp/eventlog.jsp
+++ b/ace-am/src/main/webapp/eventlog.jsp
@@ -325,7 +325,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
                         <div class="col-md-6 col-md-right-padding">
                             <div class="row">
                                 <div class="col-md-7" style="overflow-wrap: break-word;">
-                                    <span class="info"><log:LogType type="${item.logType}" /></span>
+                                    <span class="info" style="word-wrap: break-word;"><log:LogType type="${item.logType}" /></span>
                                 </div>
                                 <div class="col-md-5 col-md-right-padding">
                                     <span class="info"><log:LogCategory type="${item.logType}" /></span>


### PR DESCRIPTION
Enable collection status json output for Chron-dashboard.
Break long/overflow event log type to another line.