### PR TITLE
Add preservation storage option search to filter REMOVE state collections

### DIFF
--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -38,6 +38,10 @@
             var grouptr = 'grouptr';
             var statusrow = 'statusrow';
             var nogroup = 'nogroup';
+            var collGroups = [];
+            <c:forEach var="group" items="${colGroups}" varStatus="stat">
+                collGroups.push("${group}");   
+            </c:forEach>
 
             function search() {
                 document.getElementById('action').value = 'search';
@@ -64,16 +68,26 @@
             }
             function browseGroup(group)
             {
-                var action = document.getElementById('action').value;
-            	if (action == 'search')
-            	{
-            	    showGroup(grouptr + group)
-            	    return;
-            	}
+                if (canExpandGroups())
+                {
+                    // expend group on search, excpet search with option to filtering REMOVE state collections specifically
+                    showGroup(grouptr + group)
+                    return;
+                }
+
                 document.getElementById('group-filter').value = group;
 
                 document.getElementById("searchForm").submit();
-                
+            }
+            function canExpandGroups() {
+                var params = (new URL(document.location)).searchParams;
+                var state = params.get("status_state");
+                var action = document.getElementById('action').value;
+
+                var group = document.getElementById('group-filter').value.trim();
+                var collection = document.getElementById('coll-filter').value.trim();
+
+                return action == 'search' && (state !== 'r' || state === 'r' && (group !== '' && !collGroups.includes(group) || collection !== ''));
             }
             function hideGroup(id)
             {
@@ -101,16 +115,15 @@
                 var group = document.getElementById('group-filter').value.trim();
                 var collection = document.getElementById('coll-filter').value.trim();
 
-                // don't collpase group on search, excpet filtering out REMOVE state collections only
-                if (action === 'search' && (state !== 'r' || state === 'r' && (group !== '' || collection !== ''))) {
+                if (canExpandGroups()) {
                     return;
                 }
- 
+                // collpase groups on search, excpet filtering out REMOVE state collections only
                 var divs = document.getElementsByTagName('tr');
 
                 for (i = 0; i < divs.length; i++)
                 {
-                	var iclass = divs[i].className;
+                    var iclass = divs[i].className;
 
                     if (iclass.indexOf(groupheaderrow) == 0) {
                         var igroup = iclass.substring(iclass.indexOf(groupheaderrow) + groupheaderrow.length);

--- a/ace-am/src/main/webapp/status.jsp
+++ b/ace-am/src/main/webapp/status.jsp
@@ -94,11 +94,18 @@
             }
             function collapseGroups()
             {
+                var params = (new URL(document.location)).searchParams;
+                var state = params.get("status_state");
                 var action = document.getElementById('action').value;
-                if (action === 'search')
-                    return;
-                
+
                 var group = document.getElementById('group-filter').value.trim();
+                var collection = document.getElementById('coll-filter').value.trim();
+
+                // don't collpase group on search, excpet filtering out REMOVE state collections only
+                if (action === 'search' && (state !== 'r' || state === 'r' && (group !== '' || collection !== ''))) {
+                    return;
+                }
+ 
                 var divs = document.getElementsByTagName('tr');
 
                 for (i = 0; i < divs.length; i++)
@@ -324,6 +331,7 @@
                     <span class="input-group-addon">State</span>
                     <select name="status_state" id="state-filter" class="form-select">
                         <option value="">Select a Collection State</option>
+                        <option value="r" <c:if test="${status_state eq 'r'}">selected="selected"</c:if>>PRESERVATION STORAGE</option>
                         <c:forEach var="s" items="${states}">
                             <c:choose>
                                 <c:when test="${s.state eq status_state}">


### PR DESCRIPTION
Related to ticket #61 

Add preservation storage option search to filter REMOVE state collections.

Screenshots:
1. Search with PRESERVATION STORAGE state filter
<img width="1440" alt="Screen Shot - ACE preservation option search" src="https://user-images.githubusercontent.com/2430784/198139287-ce69c30a-f928-4aa1-a209-304220472cac.png">

2. Listing depositors/groups (collapsed)
<img width="1439" alt="Screen Shot - ACE preservation results collpased" src="https://user-images.githubusercontent.com/2430784/198138010-81d37cd3-dd77-44c5-ad6e-e4e2b4f6a3fb.png">

3. Browser depositors/groups collections (Expanded)
<img width="1440" alt="Screen Shot - ACE preservation option - browse by group" src="https://user-images.githubusercontent.com/2430784/198138940-77589f2d-0490-4481-903c-a725211fc03a.png">

4. Expanded search results
<img width="1437" alt="Screen Shot - ACE preservation option with search" src="https://user-images.githubusercontent.com/2430784/198139097-73e5b182-b049-4631-9306-508accc30009.png">
