### PR TITLE
Excluded REMOVED collections from size count by default when Status page loaded

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
@@ -150,6 +150,10 @@ public class StatusServlet extends EntityManagerServlet {
             request.setAttribute(PARAM_COLLECTION_LIKE, collection);
         }
 
+        // Status page with removed collections excluded by default
+        if(Strings.isEmpty(state) && Strings.isEmpty(action) && queries.isEmpty()) {
+            state = STATE_EXCLUDE_REMOVE;
+        }
         // Enforce that the state is not empty, or larger than 1 character.
         // Lower case r: exclude collections with REMOVE state
         // upper case R: only collections with REMOVE state


### PR DESCRIPTION
Related to #64 

Exclude REMOVE collections from size count by default when Status page loaded .


Screenshots:
<img width="1439" alt="Screen Shot - chron ACE status default" src="https://github.com/Chronopolis-Digital-Preservation/audit-control-environment/assets/2430784/679badf4-e017-4c41-ab94-5b26ac167788">

