### PR TITLE
Exclude REMOVED collections from Status page for size count by default.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/access/StatusServlet.java
@@ -151,7 +151,7 @@ public class StatusServlet extends EntityManagerServlet {
         }
 
         // Status page with removed collections excluded by default
-        if(Strings.isEmpty(state) && Strings.isEmpty(action) && queries.isEmpty()) {
+        if(Strings.isEmpty(state)) {
             state = STATE_EXCLUDE_REMOVE;
         }
         // Enforce that the state is not empty, or larger than 1 character.


### PR DESCRIPTION
Related to #64 

Exclude REMOVED collections from Status page for size count by default.

Note: With the PR, we'll see size count for active collections on Status page unless we search with the `REMOVED` option from the `State` dropdown. That is, the REMOVED collections won't show up unless we search for them.

@thorucsd @rstanonik Can we deploy it to chrondev? And if it looks good to you, just feel free to move it to chron prod so that @SibylSchaefer can review it there. Thanks.