### PR TITLE
ace-am: allow for any audit Errors (globally) to be sent to a designated email.

### DIFF
--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditConfigurationContext.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditConfigurationContext.java
@@ -236,6 +236,11 @@ public final class AuditConfigurationContext implements ServletContextListener {
                             LOG.trace("No Sync on " + c.getName());
                         }
                     }
+
+                    // Notify admin if there's any errors occurred during auditing.
+                    if (items.size() > 0) {
+                        AuditThreadFactory.notifyErrorAudits();
+                    }
                 }
             } catch (Throwable t) {
                 LOG.error("Error testing to see if collections need auditing", t);

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditConfigurationContext.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditConfigurationContext.java
@@ -98,7 +98,7 @@ public final class AuditConfigurationContext implements ServletContextListener {
         pb.setPaused(!Boolean.valueOf(enableAudits));
 
         checkTimer = new Timer("Audit Check Timer");
-        checkTimer.schedule(new MyTimerTask(pb), 0, HOUR);
+        checkTimer.schedule(new MyTimerTask(pb), 15*1000, HOUR);
 
         // set IMS for audit Thread from server parameter
         AuditThreadFactory.setIMS(resultMap.getOrDefault(PARAM_IMS, ims));
@@ -236,12 +236,10 @@ public final class AuditConfigurationContext implements ServletContextListener {
                             LOG.trace("No Sync on " + c.getName());
                         }
                     }
-
-                    // Notify admin if there's any errors occurred during auditing.
-                    if (items.size() > 0) {
-                        AuditThreadFactory.notifyErrorAudits();
-                    }
                 }
+
+                // Notify admin for error auditing.
+                AuditThreadFactory.notifyErrorAudits();
             } catch (Throwable t) {
                 LOG.error("Error testing to see if collections need auditing", t);
             } finally {

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
@@ -179,6 +179,22 @@ public final class AuditThread extends Thread implements CancelCallback {
         return coll;
     }
 
+    /**
+     * The exception throw during auditing.
+     * @return
+     */
+    public Throwable getAbortException() {
+        return abortException;
+    }
+
+    /**
+     * The flag for cancelled audit.
+     * @return
+     */
+    public boolean isCancelled() {
+        return cancel;
+    }
+
     @Override
     public void cancel() {
         LOG.info("Received cancel for audit " + coll.getName());
@@ -418,7 +434,7 @@ public final class AuditThread extends Thread implements CancelCallback {
         LOG.trace("Generating audit report on " + session + " coll "
                 + coll.getName());
         CollectionCountContext.updateCollection(coll);
-        ReportSummary rs = new SummaryGenerator(coll, session).generateReport();
+        ReportSummary rs = getReportSummary();
         try {
             SchedulerContextListener.mailReport(rs, createMailList());
         } catch (MessagingException e) {
@@ -427,6 +443,10 @@ public final class AuditThread extends Thread implements CancelCallback {
             em.close();
             LOG.error("Could not send report summary", e);
         }
+    }
+
+    public ReportSummary getReportSummary() {
+        return new SummaryGenerator(coll, session).generateReport();
     }
 
     /**

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
@@ -434,6 +434,7 @@ public final class AuditThread extends Thread implements CancelCallback {
     private void generateAuditReport() {
         LOG.trace("Generating audit report on " + session + " coll "
                 + coll.getName());
+
         CollectionCountContext.updateCollection(coll);
         ReportSummary rs = getReportSummary();
         try {

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/audit/AuditThread.java
@@ -111,6 +111,7 @@ public final class AuditThread extends Thread implements CancelCallback {
     private String tokenClassName;
     private LogEventManager logManager;
     private AuditIterable<FileBean> iterableItems;
+    private ReportSummary reportSummary = null;
 
     public AuditThread(Collection c,
                        StorageDriver driver,
@@ -249,7 +250,7 @@ public final class AuditThread extends Thread implements CancelCallback {
                 performAudit();
             } catch (Throwable e) {
                 LOG.fatal("Uncaught exception in performAudit()", e);
-                if (abortException != null) {
+                if (abortException == null) {
                     abortException = e;
                 }
             }
@@ -445,8 +446,15 @@ public final class AuditThread extends Thread implements CancelCallback {
         }
     }
 
-    public ReportSummary getReportSummary() {
-        return new SummaryGenerator(coll, session).generateReport();
+    /**
+     * Generate report summary for audit.
+     */
+    public synchronized ReportSummary getReportSummary() {
+        if (reportSummary == null) {
+            reportSummary = new SummaryGenerator(coll, session).generateReport();
+        }
+
+        return reportSummary;
     }
 
     /**

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/reporting/SchedulerContextListener.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/reporting/SchedulerContextListener.java
@@ -187,11 +187,12 @@ public class SchedulerContextListener implements ServletContextListener {
      */
     public static void sendMail(String subject, String content, String[] mailList)
             throws MessagingException {
-        LOG.debug("ACE audit report email list: " + String.join(", ", mailList) + ". Subject: " + subject + ", content: " + content);
-
         if (content == null || mailList == null || mailList.length == 0) {
+            LOG.debug("Empty mail list or content for " + subject);
             return;
         }
+
+        LOG.debug("ACE audit report email list: " + String.join(", ", mailList) + ". Subject: " + subject + ", content: " + content);
 
         boolean debug = false;
 

--- a/ace-am/src/main/java/edu/umiacs/ace/monitor/settings/SettingsConstants.java
+++ b/ace-am/src/main/java/edu/umiacs/ace/monitor/settings/SettingsConstants.java
@@ -38,6 +38,7 @@ public class SettingsConstants {
     public static final String auditSample = "false";
     public static final String mailServer = "localhost.localdomain";
     public static final String mailFrom = "acemail@localhost";
+    public static final String mailTo = "acemail@localhost";
     public static final String maxAudit = "3";
     public static final String autoAudit = "true";
     public static final String ims = "ims.tdl.org";

--- a/ace-am/src/main/webapp/settings.jsp
+++ b/ace-am/src/main/webapp/settings.jsp
@@ -71,6 +71,14 @@
                 <input class="form-input-settings" type="text" id="mail.from" name="mail.from"
                        value="${currSettings['mail.from']}"/>
             </div>
+            <div class="form-field">
+                <label class="form-label" for="mail.to">Mail To</label>
+                <span class="form-help">
+                Set this e-mail address to an admin e-mail that should be sent on audit error
+            </span>
+                <input class="form-input-settings" type="text" id="mail.to" name="mail.to"
+                       value="${currSettings['mail.to']}"/>
+            </div>
         </div>
 
         <div class="tab-block" id="audit-settings">


### PR DESCRIPTION
Related to #67 

Send audit errors globally to a designated email for admin notification:
- The designated email account can be set in the `System Settings` page `Mail To` field, `/ace-am/UpdateSettings`. Multiple emails can be delimited by comma (,).
- Error audit reports will be aggregated from multiple collections that are audited in the same schedule process.

Screenshots:
- Mail To email for audit Errors sent globally
<img width="1440" alt="Screen Shot - ACE System Setting - admin email" src="https://github.com/Chronopolis-Digital-Preservation/audit-control-environment/assets/2430784/efdf41c8-3aa2-4fc9-a81b-e2166943c939">

