### PR TITLE
Fix compile problem, use central repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,16 @@
                 <version>${jaxws.version}</version>
             </dependency>
 
+            <!-- com.sun.xml.ws:policy:2.7.5 (pulled in by jaxws-rt) depends on
+                 org.glassfish.jaxb:txw2:2.4.0-b180608.0325, a nightly build that was
+                 only ever published to the now-decommissioned java.net/glassfish Nexus
+                 repositories. Pin to a stable release available on Central instead. -->
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>txw2</artifactId>
+                <version>2.3.9</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Compile was failing because used old, missing repos. Modify pom.xml to use "central" repos.

Here's what Claude said.

● Root cause

  The failing repository (releases.java.net, id jvnet-nexus-releases) isn't declared anywhere in this project's own POMs. It's inherited from   net.java:jvnet-parent:5 — the ancestor POM of com.sun.xml.ws:policy:2.7.5, a transitive dependency pulled in by jaxws-rt:2.3.1 (declared in   ace-ims-ws/pom.xml). That parent POM still points at the long-dead maven.java.net Nexus, whose TLS cert expired 2026-04-01.

  Worse, even ignoring the expired cert, the specific artifact being requested — org.glassfish.jaxb:txw2:2.4.0-b180608.0325 — was a one-off nightly   build that was only ever hosted there; it was never published to Maven Central. So a mirror/proxy workaround wouldn't have helped either.

  Fix

  In the root pom.xml's <dependencyManagement>, I added a managed override pinning org.glassfish.jaxb:txw2 to 2.3.9 — a stable release in the same   2.3.x line, available on Central — so the transitive resolution never needs to reach the dead java.net repo at all.
