### PR TITLE
Don't use SSL for MySQL

### DIFF
--- a/ace-am/src/main/webapp/META-INF/context.xml
+++ b/ace-am/src/main/webapp/META-INF/context.xml
@@ -16,5 +16,5 @@
        'name' is the resource name used by the web app to refer to this
        database and NOT the database name, do not change unless you want bad
        things to happen.-->
-  <Resource auth="Container" driverClassName="com.mysql.jdbc.Driver" maxActive="20" maxIdle="10" maxWait="-1" name="jdbc/aceamdb" password="ace" testOnBorrow="true" type="javax.sql.DataSource" url="jdbc:mysql://localhost/aceam?characterEncoding=UTF-8" username="aceam" validationQuery="SELECT 1"/>
+  <Resource auth="Container" driverClassName="com.mysql.jdbc.Driver" maxActive="20" maxIdle="10" maxWait="-1" name="jdbc/aceamdb" password="ace" testOnBorrow="true" type="javax.sql.DataSource" url="jdbc:mysql://localhost/aceam?characterEncoding=UTF-8&amp;useSSL=false" username="aceam" validationQuery="SELECT 1"/>
 </Context>


### PR DESCRIPTION
Something about the mysql jdbc connection changed. Probably some new security default requiring SSL. 

Solution: disable SSL for mysql connection.

```
29-Jul-2026 13:49:38.759 SEVERE [main] org.apache.catalina.core.StandardContext.startInternal One or more listeners failed to start. Full details will be found in the appropriate container log file
29-Jul-2026 13:49:38.762 SEVERE [main] org.apache.catalina.core.StandardContext.startInternal Context [/ace-am] startup failed due to previous errors
2026-07-29 13:49:38,764 [main] DEBUG edu.umiacs.ace.monitor.register.IngestThreadPool - [Ingest] Shutting down thread pools.
2026-07-29 13:49:38,764 [main] DEBUG edu.umiacs.ace.monitor.reporting.SchedulerContextListener - Shutting down the scheduler
_JPAEclipseLinkSessionCustomizer: configured java:comp/env/jdbc/aceamdb
[EL Info]: 2026-07-29 13:49:38.765--ServerSession(482041911)--EclipseLink, version: Eclipse Persistence Services - 2.7.4.v20190115-ad5b7c6b2a
Wed Jul 29 13:49:38 PDT 2026 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.
[EL Severe]: ejb: 2026-07-29 13:49:38.767--ServerSession(482041911)--Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.7.4.v20190115-ad5b7c6b2a): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: java.sql.SQLException: Cannot create PoolableConnectionFactory (Communications link failure

```